### PR TITLE
Replace StringBuffer with StringBuilder inside the method

### DIFF
--- a/escheduler-common/src/main/java/cn/escheduler/common/shell/AbstractShell.java
+++ b/escheduler-common/src/main/java/cn/escheduler/common/shell/AbstractShell.java
@@ -157,7 +157,7 @@ public abstract class AbstractShell {
     BufferedReader inReader = 
             new BufferedReader(new InputStreamReader(process
                                                      .getInputStream()));
-    final StringBuffer errMsg = new StringBuffer();
+    final StringBuilder errMsg = new StringBuilder();
     
     // read error and input streams as this would free up the buffers
     // free the error stream buffer

--- a/escheduler-dao/src/main/java/cn/escheduler/dao/mapper/ProcessInstanceMapperProvider.java
+++ b/escheduler-dao/src/main/java/cn/escheduler/dao/mapper/ProcessInstanceMapperProvider.java
@@ -354,7 +354,7 @@ public class ProcessInstanceMapperProvider {
      * @return
      */
     public String listByStatus(Map<String, Object> parameter) {
-        StringBuffer strStates = new StringBuffer();
+        StringBuilder strStates = new StringBuilder();
         int[] stateArray = (int[]) parameter.get("states");
 
         for(int i=0;i<stateArray.length;i++){
@@ -387,7 +387,7 @@ public class ProcessInstanceMapperProvider {
      * @return
      */
     public String queryByHostAndStatus(Map<String, Object> parameter) {
-        StringBuffer strStates = new StringBuffer();
+        StringBuilder strStates = new StringBuilder();
         int[] stateArray = (int[]) parameter.get("states");
 
         for(int i=0;i<stateArray.length;i++){
@@ -425,7 +425,7 @@ public class ProcessInstanceMapperProvider {
      * @return
      */
     public String setFailoverByHostAndStateArray(Map<String, Object> parameter) {
-        StringBuffer strStates = new StringBuffer();
+        StringBuilder strStates = new StringBuilder();
         int[] stateArray = (int[]) parameter.get("states");
 
         for(int i=0;i<stateArray.length;i++){
@@ -563,7 +563,7 @@ public class ProcessInstanceMapperProvider {
     }
 
     public String queryLastRunningProcess(Map<String, Object> parameter) {
-        StringBuffer strStates = new StringBuffer();
+        StringBuilder strStates = new StringBuilder();
         int[] stateArray = (int[]) parameter.get("states");
 
         for(int i=0;i<stateArray.length;i++){

--- a/escheduler-dao/src/main/java/cn/escheduler/dao/mapper/ScheduleMapperProvider.java
+++ b/escheduler-dao/src/main/java/cn/escheduler/dao/mapper/ScheduleMapperProvider.java
@@ -163,7 +163,7 @@ public class ScheduleMapperProvider {
    */
   public String selectAllByProcessDefineArray(Map<String, Object> parameter) {
 
-    StringBuffer strIds = new StringBuffer();
+    StringBuilder strIds = new StringBuilder();
     int[] idsArray = (int[]) parameter.get("processDefineIds");
     for(int i=0;i<idsArray.length;i++){
       strIds.append(idsArray[i]);

--- a/escheduler-dao/src/main/java/cn/escheduler/dao/mapper/TaskInstanceMapperProvider.java
+++ b/escheduler-dao/src/main/java/cn/escheduler/dao/mapper/TaskInstanceMapperProvider.java
@@ -213,7 +213,7 @@ public class TaskInstanceMapperProvider {
      * @return
      */
     public String queryByHostAndStatus(Map<String, Object> parameter) {
-        StringBuffer strStates = new StringBuffer();
+        StringBuilder strStates = new StringBuilder();
         int[] stateArray = (int[]) parameter.get("states");
         for(int i=0;i<stateArray.length;i++){
             strStates.append(stateArray[i]);
@@ -246,7 +246,7 @@ public class TaskInstanceMapperProvider {
      * @return
      */
     public String queryLimitNumByHostAndStatus(Map<String, Object> parameter) {
-        StringBuffer strStates = new StringBuffer();
+        StringBuilder strStates = new StringBuilder();
         int[] stateArray = (int[]) parameter.get("states");
         for(int i=0;i<stateArray.length;i++){
             strStates.append(stateArray[i]);
@@ -278,7 +278,7 @@ public class TaskInstanceMapperProvider {
      * @return
      */
     public String setFailoverByHostAndStateArray(Map<String, Object> parameter) {
-        StringBuffer strStates = new StringBuffer();
+        StringBuilder strStates = new StringBuilder();
         int[] stateArray = (int[]) parameter.get("states");
         int state = ExecutionStatus.NEED_FAULT_TOLERANCE.ordinal();
         for(int i=0;i<stateArray.length;i++){
@@ -419,7 +419,7 @@ public class TaskInstanceMapperProvider {
      */
     public String countTask(Map<String, Object> parameter){
 
-        StringBuffer taskIdsStr = new StringBuffer();
+        StringBuilder taskIdsStr = new StringBuilder();
         int[] stateArray = (int[]) parameter.get("taskIds");
         for(int i=0;i<stateArray.length;i++){
             taskIdsStr.append(stateArray[i]);


### PR DESCRIPTION
Using `StringBuilder` inside the method has better performance than using `StringBuffer`, because there is no thread safety problem in this case.
So I replacing `StringBuffer` with `StringBuilder` inside the method in this PR.