### PR TITLE
update escheduler-common pom.xml

### DIFF
--- a/escheduler-common/pom.xml
+++ b/escheduler-common/pom.xml
@@ -572,6 +572,12 @@
 		<dependency>
 			<groupId>org.mortbay.jetty</groupId>
 			<artifactId>jsp-2.1</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.mortbay.jetty</groupId>
+					<artifactId>servlet-api-2.5</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
[BUG][#860] jar包冲突Correct the classpath of your application so that it contains a single, compatible version of javax.servlet.ServletContext