### PR TITLE
increase udf classname lenth limit

### DIFF
--- a/escheduler-ui/src/js/conf/home/pages/resource/pages/udf/pages/function/_source/createUdf.vue
+++ b/escheduler-ui/src/js/conf/home/pages/resource/pages/udf/pages/function/_source/createUdf.vue
@@ -27,7 +27,7 @@
           <template slot="content">
             <x-input
                     type="input"
-                    maxlength="40"
+                    maxlength="100"
                     v-model="className"
                     :placeholder="$t('Please enter a Package name')">
             </x-input>


### PR DESCRIPTION
The class name with package name will be very long in large projects. It is recommended to increase the maximum length limit to 100(mysql t_escheduler_udfs.class_name is already varchar 255).