### PR TITLE
[Enhancement] params support cross-reference etc.

### DIFF
--- a/escheduler-common/src/main/java/cn/escheduler/common/utils/ParameterUtils.java
+++ b/escheduler-common/src/main/java/cn/escheduler/common/utils/ParameterUtils.java
@@ -59,6 +59,8 @@ public class ParameterUtils {
 
     if (StringUtils.isNotEmpty(cronTimeStr)) {
       try {
+        // prevent having ${}
+        cronTimeStr = PlaceholderUtils.replacePlaceholders(cronTimeStr, parameterMap, true);
         cronTime = DateUtils.parseDate(cronTimeStr, new String[]{Constants.PARAMETER_FORMAT_TIME});
       } catch (ParseException e) {
         logger.error(String.format("parse %s exception", cronTimeStr), e);


### PR DESCRIPTION
1. Complements are more friendly:

Before modification: The formatting time defaults to the current time. If system.datetime param is defined, the parameters are directly parsed in yyyMMddHmmss format (without passing custom parameters).

After modification: the parameter ${system.datetime}= ${system.biz.date} 0000000 can be defined, so that when the program obtains formatting time (e.g. $[MMdd]), whether the complement or normal cron task, the results are consistent with expectations.

2. Parameters support cross-reference

Use case: Hive loads partition SQL, location needs '/path/2019/09/27'.

Before modification: LOCATION ${hdfs.path}/$[yyyy]/$[MM]/$[dd] is parsed into LOCATION'/path'/'2019'/'09'/'27'(Redundant single quotation marks.INT type fails either.Will becoming 9, missing 0) according to JDBC parameters.

After modification: defining parameters 
param.yyyy=$[yyyyy], param.MM=$[MM], param.dd=$[dd], final.path=${hdfs.path}/${param.yyyy}/${param.MM}/${param.dd}. 
SQL: ALTER TABLE ... ADD PARTITION ... LOCATION ${final.path} 
will be resolved to the correct: location '/path/2019/09/27'.

***

1.补数更加友好：

修改前：格式化默认按当前时间，如果定义了system.datetime，则按yyyyMMddHHmmss格式直接解析参数值(无法带参数)。

修改后：可以定义参数${system.datetime}=${system.biz.date}0000000，这样程序获取格式化时间时(例如$[MMdd])，无论是补数还是正常cron任务，结果均与预期相符。

2.参数支持互相引用

使用场景：Hive加载分区SQL，location需要'/path/2019/09/27'。

修改前：LOCATION ${hdfs.path}/$[yyyy]/$[MM]/$[dd]按照JDBC参数被解析成LOCATION '/path'/'2019'/'09'/'27'(多余单引号。INT类型也不行，会变成9，缺少0)

修改后：定义参数
param.yyyy=$[yyyy],param.MM=$[MM],param.dd=$[dd],
final.path=${hdfs.path}/${param.yyyy}/${param.MM}/${param.dd}.
SQL: ALTER TABLE ... ADD PARTITION ... LOCATION ${final.path}
会被解析成正确的location '/path/2019/09/27'.