### PR TITLE
[Enhancement] support custom host by environment variables when running on docker(#989)

### DIFF
--- a/escheduler-common/src/main/java/cn/escheduler/common/utils/OSUtils.java
+++ b/escheduler-common/src/main/java/cn/escheduler/common/utils/OSUtils.java
@@ -238,7 +238,12 @@ public class OSUtils {
    */
   public static String getHost(){
     try {
-      return InetAddress.getLocalHost().getHostAddress();
+      String hostIP = System.getenv("DS_HOST_IP");
+      if (StringUtils.isNotBlank(hostIP)) {
+        return hostIP;
+      } else {
+        return InetAddress.getLocalHost().getHostAddress();
+      }
     } catch (UnknownHostException e) {
       logger.error(e.getMessage(),e);
     }


### PR DESCRIPTION
#989 

This can be resolved by setting DS_HOST_IP environment variables.
If this env exists, just using it, otherwise get a local IP by Java api.

And it is easier to use when running on kubernetes
```
env:
- name: DS_HOST_IP
  valueFrom:
    fieldRef:
      fieldPath: status.podIP
```

![深度截图_选择区域_20191011203025](https://user-images.githubusercontent.com/2173239/66651627-14206f00-ec66-11e9-985c-30f9e3de5551.png)

