### PR TITLE
move batchDelete Process Define/Instance Outside for transactional

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ProcessDefinitionService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ProcessDefinitionService.java
@@ -39,7 +39,6 @@ import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.commons.lang3.ObjectUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.dolphinscheduler.api.utils.CheckUtils;
 import org.apache.dolphinscheduler.dao.entity.*;
 import org.apache.dolphinscheduler.dao.mapper.*;
@@ -415,55 +414,6 @@ public class ProcessDefinitionService extends BaseDAGService {
             putMsg(result, Status.SUCCESS);
         } else {
             putMsg(result, Status.DELETE_PROCESS_DEFINE_BY_ID_ERROR);
-        }
-        return result;
-    }
-
-    /**
-     * batch delete process definition by ids
-     *
-     * @param loginUser login user
-     * @param projectName project name
-     * @param processDefinitionIds process definition id
-     * @return delete result code
-     */
-    public Map<String, Object> batchDeleteProcessDefinitionByIds(User loginUser, String projectName, String processDefinitionIds) {
-
-        Map<String, Object> result = new HashMap<>(5);
-
-        Map<String, Object> deleteReuslt = new HashMap<>(5);
-
-        List<Integer> deleteFailedIdList = new ArrayList<Integer>();
-        Project project = projectMapper.queryByName(projectName);
-
-        Map<String, Object> checkResult = projectService.checkProjectAndAuth(loginUser, project, projectName);
-        Status resultEnum = (Status) checkResult.get(Constants.STATUS);
-        if (resultEnum != Status.SUCCESS) {
-            return checkResult;
-        }
-
-
-        if(StringUtils.isNotEmpty(processDefinitionIds)){
-            String[] processInstanceIdArray = processDefinitionIds.split(",");
-
-            for (String strProcessInstanceId:processInstanceIdArray) {
-                int processInstanceId = Integer.parseInt(strProcessInstanceId);
-                try {
-                    deleteReuslt = deleteProcessDefinitionById(loginUser, projectName, processInstanceId);
-                    if(!Status.SUCCESS.equals(deleteReuslt.get(Constants.STATUS))){
-                        deleteFailedIdList.add(processInstanceId);
-                        logger.error((String)deleteReuslt.get(Constants.MSG));
-                    }
-                } catch (Exception e) {
-                    deleteFailedIdList.add(processInstanceId);
-                }
-            }
-        }
-
-        if(deleteFailedIdList.size() > 0){
-            putMsg(result, Status.BATCH_DELETE_PROCESS_DEFINE_BY_IDS_ERROR,StringUtils.join(deleteFailedIdList.toArray(),","));
-        }else{
-            putMsg(result, Status.SUCCESS);
         }
         return result;
     }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ProcessInstanceService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ProcessInstanceService.java
@@ -31,7 +31,6 @@ import org.apache.dolphinscheduler.common.model.TaskNode;
 import org.apache.dolphinscheduler.common.model.TaskNodeRelation;
 import org.apache.dolphinscheduler.common.process.Property;
 import org.apache.dolphinscheduler.common.queue.ITaskQueue;
-import org.apache.dolphinscheduler.common.queue.TaskQueueFactory;
 import org.apache.dolphinscheduler.common.utils.*;
 import org.apache.dolphinscheduler.common.utils.placeholder.BusinessTimeUtils;
 import org.apache.dolphinscheduler.dao.ProcessDao;
@@ -551,50 +550,6 @@ public class ProcessInstanceService extends BaseDAGService {
             putMsg(result, Status.SUCCESS);
         } else {
             putMsg(result, Status.DELETE_PROCESS_INSTANCE_BY_ID_ERROR);
-        }
-
-        return result;
-    }
-
-    /**
-     * batch delete process instance by ids, at the same time，delete task instance and their mapping relation data
-     *
-     * @param loginUser login user
-     * @param projectName project name
-     * @param processInstanceIds process instance id
-     * @return delete result code
-     */
-    public Map<String, Object> batchDeleteProcessInstanceByIds(User loginUser, String projectName, String processInstanceIds) {
-        // task queue
-        ITaskQueue tasksQueue = TaskQueueFactory.getTaskQueueInstance();
-
-        Map<String, Object> result = new HashMap<>(5);
-        List<Integer> deleteFailedIdList = new ArrayList<Integer>();
-
-        Project project = projectMapper.queryByName(projectName);
-
-        Map<String, Object> checkResult = projectService.checkProjectAndAuth(loginUser, project, projectName);
-        Status resultEnum = (Status) checkResult.get(Constants.STATUS);
-        if (resultEnum != Status.SUCCESS) {
-            return checkResult;
-        }
-
-        if(StringUtils.isNotEmpty(processInstanceIds)){
-            String[] processInstanceIdArray = processInstanceIds.split(",");
-
-            for (String strProcessInstanceId:processInstanceIdArray) {
-                int processInstanceId = Integer.parseInt(strProcessInstanceId);
-                try {
-                    deleteProcessInstanceById(loginUser, projectName, processInstanceId,tasksQueue);
-                } catch (Exception e) {
-                    deleteFailedIdList.add(processInstanceId);
-                }
-            }
-        }
-        if(deleteFailedIdList.size() > 0){
-            putMsg(result, Status.BATCH_DELETE_PROCESS_INSTANCE_BY_IDS_ERROR,StringUtils.join(deleteFailedIdList.toArray(),","));
-        }else{
-            putMsg(result, Status.SUCCESS);
         }
 
         return result;

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProcessDefinitionServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProcessDefinitionServiceTest.java
@@ -76,15 +76,4 @@ public class ProcessDefinitionServiceTest {
         Assert.assertEquals(Status.PROJECT_NOT_FOUNT, map.get(Constants.STATUS));
         logger.info(JSON.toJSONString(map));
     }
-
-    @Test
-    public void batchDeleteProcessDefinitionByIds() throws Exception {
-
-        User loginUser = new User();
-        loginUser.setId(-1);
-        loginUser.setUserType(UserType.GENERAL_USER);
-        Map<String, Object> map = processDefinitionService.batchDeleteProcessDefinitionByIds(loginUser, "li_test_1", "2,3");
-        Assert.assertEquals(Status.PROJECT_NOT_FOUNT, map.get(Constants.STATUS));
-        logger.info(JSON.toJSONString(map));
-    }
 }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProcessInstanceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProcessInstanceServiceTest.java
@@ -80,16 +80,4 @@ public class ProcessInstanceServiceTest {
         Assert.assertEquals(Status.PROJECT_NOT_FOUNT, map.get(Constants.STATUS));
         logger.info(JSON.toJSONString(map));
     }
-
-    @Test
-    public void batchDeleteProcessInstanceByIds() throws Exception {
-
-        User loginUser = new User();
-        loginUser.setId(-1);
-        loginUser.setUserType(UserType.GENERAL_USER);
-        Map<String, Object> map = processInstanceService.batchDeleteProcessInstanceByIds(loginUser, "li_test_1", "4,2,300");
-
-        Assert.assertEquals(Status.PROJECT_NOT_FOUNT, map.get(Constants.STATUS));
-        logger.info(JSON.toJSONString(map));
-    }
 }


### PR DESCRIPTION
Currently, the  batchDeleteProcessDefinitionByIds  & batchDeleteProcessInstanceByIds  (batch operations) has Transaction problems.  

they will make the inner function   deleteProcessDefinitionById  and  deleteProcessInstanceById  not transactional even if they are marked as so.   If those two deleteProcessDefinitionById  and  deleteProcessInstanceById  are  called inside batchDeleteProcessDefinitionByIds  & batchDeleteProcessInstanceByIds  .  so we need to move those batch operation out.


You can refer to https://stackoverflow.com/questions/25738883/spring-transactional-annotation-when-using-try-catch-block
---------
In proxy mode (which is the default), only external method calls coming in through the proxy are intercepted. This means that self-invocation, in effect, a method within the target object calling another method of the target object, will not lead to an actual transaction at runtime even if the invoked method is marked with @Transactional.
---------