### PR TITLE
[dolphinscheduler-#184] [enhancement]Use the default workgroup in the page ,Instead of the value id.

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/formModel.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/formModel.vue
@@ -369,7 +369,6 @@
         }
 
         $(`#${this.id}`).find('span').text(this.name)
-
         // Store the corresponding node data structure
         this.$emit('addTaskInfo', {
           item: {
@@ -455,7 +454,23 @@
           this.description = o.description
           this.maxRetryTimes = o.maxRetryTimes
           this.retryInterval = o.retryInterval
-          this.workerGroupId = o.workerGroupId
+
+          // If the workergroup has been deleted, set the default workergroup
+          var hasMatch = false;
+          for (let i = 0; i < this.store.state.security.workerGroupsListAll.length; i++) {
+            var workerGroupId = this.store.state.security.workerGroupsListAll[i].id
+            if (o.workerGroupId == workerGroupId) {
+              hasMatch = true;
+              break;
+            }
+          }
+
+          if(!hasMatch){
+            this.workerGroupId = -1
+          }else{
+            this.workerGroupId = o.workerGroupId
+          }
+
         }
       }
       this.isContentBox = true


### PR DESCRIPTION
## What is the purpose of the pull request

When workgroup referenced by workflow , And there isn’t any instace in
workflow ,the workgroup can be delete . After the workgroup delete , Use the
default workgroup in the page ,Instead of the value id.

## Brief change log
  - Edit formModel.vue

   Add judgment rules for the workgroupId, When the workerGroupId do not match any item in workerGroupsListAll , Set it to -1

## Verify this pull request

  - Manually verified the change by testing locally.
