### PR TITLE
[dolphinscheduler-#1399][bug]fix the wrong order

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/ResourcesController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/ResourcesController.java
@@ -314,7 +314,7 @@ public class ResourcesController extends BaseController{
     ) {
         try{
             logger.info("login user {}, online create resource! fileName : {}, type : {}, suffix : {},desc : {},content : {}",
-                    loginUser.getUserName(),type,fileName,fileSuffix,description,content);
+                    loginUser.getUserName(),fileName,type,fileSuffix,description,content);
             if(StringUtils.isEmpty(content)){
                 logger.error("resource file contents are not allowed to be empty");
                 return error(Status.RESOURCE_FILE_IS_EMPTY.getCode(), RESOURCE_FILE_IS_EMPTY.getMsg());


### PR DESCRIPTION
##  What is the purpose of the pull request

To fix the bug #1399 , The method onlineCreateResource in class ResourcesController，The logger.info has wrong field order with fileName and type. Just swap their order.

## Brief change log

  -  Edit the ResourcesController.onlineCreateResource method.

## Verify this pull request

  - Manually verified the change by testing locally.
