### PR TITLE
[dolphinscheduler-#1397] [bug]Resources can not be previewed or updated 

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ResourcesService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ResourcesService.java
@@ -227,9 +227,18 @@ public class ResourcesService extends BaseService {
             }
         }
 
-        // updateProcessInstance data
+        //get the file suffix
+        String suffix = originResourceName.substring(originResourceName.lastIndexOf("."));
+
+        //if the name without suffix then add it ,else use the origin name
+        String nameWithSuffix = name;
+        if(!name.endsWith(suffix)){
+            nameWithSuffix = nameWithSuffix + suffix;
+        }
+
+        // updateResource data
         Date now = new Date();
-        resource.setAlias(name);
+        resource.setAlias(nameWithSuffix);
         resource.setDescription(desc);
         resource.setUpdateTime(now);
 


### PR DESCRIPTION
## What is the purpose of the pull request

For fix the bug #1397 .

Because when create an resource the name will add the suffix, But When rename the resource there is no suffix add to the name, So When update resource name without suffix just like "test.sh" => "test" , Then the bug reproduced.

So  i add the logic bellow:
When rename, if the name without suffix then add it ,else use the origin name.

## Brief change log

  -  Edit the ResourcesService.javal

## Verify this pull request

  - Manually verified the change by testing locally.
