### PR TITLE
Remove duplicate JDBC class driver which define in Constants.java 

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/Constants.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/Constants.java
@@ -605,51 +605,6 @@ public final class Constants {
 
 
     /**
-     * jdbc class name
-     */
-    /**
-     * mysql
-     */
-    public static final String JDBC_MYSQL_CLASS_NAME = "com.mysql.jdbc.Driver";
-
-    /**
-     * postgresql
-     */
-    public static final String JDBC_POSTGRESQL_CLASS_NAME = "org.postgresql.Driver";
-
-    /**
-     * hive
-     */
-    public static final String JDBC_HIVE_CLASS_NAME = "org.apache.hive.jdbc.HiveDriver";
-
-    /**
-     * spark
-     */
-    public static final String JDBC_SPARK_CLASS_NAME = "org.apache.hive.jdbc.HiveDriver";
-
-    /**
-     * ClickHouse
-     */
-    public static final String JDBC_CLICKHOUSE_CLASS_NAME = "ru.yandex.clickhouse.ClickHouseDriver";
-
-    /**
-     * Oracle
-     */
-    public static final String JDBC_ORACLE_CLASS_NAME = "oracle.jdbc.driver.OracleDriver";
-
-    /**
-     * Oracle
-     */
-    public static final String JDBC_SQLSERVER_CLASS_NAME = "com.microsoft.sqlserver.jdbc.SQLServerDriver";
-
-
-    /**
-     * DB2
-     */
-    public static final String JDBC_DB2_CLASS_NAME = "com.ibm.db2.jcc.DB2Driver";
-
-
-    /**
      * spark params constant
      */
     public static final String MASTER = "--master";

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/job/db/DataSourceFactory.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/job/db/DataSourceFactory.java
@@ -65,28 +65,28 @@ public class DataSourceFactory {
   public static void loadClass(DbType dbType) throws Exception{
     switch (dbType){
       case MYSQL :
-        Class.forName(Constants.JDBC_MYSQL_CLASS_NAME);
+        Class.forName(Constants.COM_MYSQL_JDBC_DRIVER);
         break;
       case POSTGRESQL :
-        Class.forName(Constants.JDBC_POSTGRESQL_CLASS_NAME);
+        Class.forName(Constants.ORG_POSTGRESQL_DRIVER);
         break;
       case HIVE :
-        Class.forName(Constants.JDBC_HIVE_CLASS_NAME);
+        Class.forName(Constants.ORG_APACHE_HIVE_JDBC_HIVE_DRIVER);
         break;
       case SPARK :
-        Class.forName(Constants.JDBC_SPARK_CLASS_NAME);
+        Class.forName(Constants.ORG_APACHE_HIVE_JDBC_HIVE_DRIVER);
         break;
       case CLICKHOUSE :
-        Class.forName(Constants.JDBC_CLICKHOUSE_CLASS_NAME);
+        Class.forName(Constants.COM_CLICKHOUSE_JDBC_DRIVER);
         break;
       case ORACLE :
-        Class.forName(Constants.JDBC_ORACLE_CLASS_NAME);
+        Class.forName(Constants.COM_ORACLE_JDBC_DRIVER);
         break;
       case SQLSERVER:
-        Class.forName(Constants.JDBC_SQLSERVER_CLASS_NAME);
+        Class.forName(Constants.COM_SQLSERVER_JDBC_DRIVER);
         break;
       case DB2:
-        Class.forName(Constants.JDBC_DB2_CLASS_NAME);
+        Class.forName(Constants.COM_DB2_JDBC_DRIVER);
         break;
       default:
         logger.error("not support sql type: {},can't load class", dbType);


### PR DESCRIPTION
## What is the purpose of the pull request

For #1425

JDBC class driver are duplicate define in Constants.java ,such as:
```
public static final String JDBC_POSTGRESQL_CLASS_NAME = "org.postgresql.Driver";

and

public static final String ORG_POSTGRESQL_DRIVER = "org.postgresql.Driver";
```
There are same effect, We can only use one of them.


## Brief change log


  - *Edit DataSourceFactory.java*
  - *Edit Constants.java*

## Verify this pull request

  - *Manually verified the change by testing locally.*
