### PR TITLE
bug：Monitoring center dashboard display problems

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/pages/monitor/pages/servers/master.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/monitor/pages/servers/master.vue
@@ -96,7 +96,8 @@
       this.getMasterData().then(res => {
         this.masterList = _.map(res, (v, i) => {
           return _.assign(v, {
-            resInfo: JSON.parse(v.resInfo)
+            resInfo: JSON.parse(v.resInfo),
+            id: i
           })
         })
         this.isLoading = false

--- a/dolphinscheduler-ui/src/js/conf/home/pages/monitor/pages/servers/worker.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/monitor/pages/servers/worker.vue
@@ -97,7 +97,8 @@
       this.getWorkerData().then(res => {
         this.workerList = _.map(res, (v, i) => {
           return _.assign(v, {
-            resInfo: JSON.parse(v.resInfo)
+            resInfo: JSON.parse(v.resInfo),
+            id: i
           })
         })
         this.isLoading = false


### PR DESCRIPTION
描述：多个master或worker节点时，监控中心UI只显示第一个节点的仪表盘信息
原因：数组未设置id字段，导致页面循环时，渲染的组件id是一样的

Fixes #645 