### PR TITLE
Improve ParameterUtils.setInParameter, Use Datetype instead of String.

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/ParameterUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/ParameterUtils.java
@@ -98,11 +98,11 @@ public class ParameterUtils {
     }else if (dataType.equals(DataType.DOUBLE)){
       stmt.setDouble(index, Double.parseDouble(value));
     }else if (dataType.equals(DataType.DATE)){
-      stmt.setString(index, value);
+      stmt.setDate(index, java.sql.Date.valueOf(value));
     }else if (dataType.equals(DataType.TIME)){
       stmt.setString(index, value);
     }else if (dataType.equals(DataType.TIMESTAMP)){
-      stmt.setString(index, value);
+      stmt.setTimestamp(index, java.sql.Timestamp.valueOf(value));
     }else if (dataType.equals(DataType.BOOLEAN)){
       stmt.setBoolean(index,Boolean.parseBoolean(value));
     }

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/sql/SqlTask.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/sql/SqlTask.java
@@ -211,7 +211,7 @@ public class SqlTask extends AbstractTask {
         if (StringUtils.isNotEmpty(sqlParameters.getTitle())){
             String title = ParameterUtils.convertParameterPlaceholders(sqlParameters.getTitle(),
                     ParamUtils.convert(paramsMap));
-            logger.info("SQL tile : {}",title);
+            logger.info("SQL title : {}",title);
             sqlParameters.setTitle(title);
         }
 


### PR DESCRIPTION
 ## What is the purpose of the pull request

For bug #1379.

Now all datatype use same method ` stmt.setString(index,value);` even DATE and TIMESTAMP.

So i had improved it. If datatype is DATE use `stmt.setDate(index, java.sql.Date.valueOf(value));` ,
 if datatype is TIMESTAMP use `stmt.setTimestamp(index, java.sql.Timestamp.valueOf(value));`.i

When use DATE , datatype must use Date and the param format must use `$[yyyy-MM-dd]` , 
When use TIMESTAMP , datatype must use TIMESTAMP and the param format must use `$[yyyy-MM-dd hh:mm:ss]`.

## Brief change log

  - *Edit ParameterUtils.java*
  - *Fix wrong spell in SqlTask.java*

## Verify this pull request

  - *Manually verified the change by testing locally.*
