### PR TITLE
add Apache 1.1 licenses statistic for commons-el 1.0

### DIFF
--- a/dolphinscheduler-dist/dolphinscheduler-backend/src/main/release-docs/LICENSE
+++ b/dolphinscheduler-dist/dolphinscheduler-backend/src/main/release-docs/LICENSE
@@ -209,6 +209,15 @@ subcomponents is subject to the terms and conditions of the following
 licenses.
 
 ========================================================================
+Apache 1.1 licenses
+========================================================================
+
+The following components are provided under the Apache License. See project link for details.
+The text of each license is also included at licenses/LICENSE-[project].txt.
+
+    commons-el 1.0: http://commons.apache.org/dormant/commons-el/, Apache 1.1
+
+========================================================================
 Apache 2.0 licenses
 ========================================================================
 
@@ -235,7 +244,6 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     commons-configuration 1.10: https://mvnrepository.com/artifact/commons-configuration/commons-configuration/1.10, Apache 2.0
     commons-daemon 1.0.13 https://mvnrepository.com/artifact/commons-daemon/commons-daemon/1.0.13, Apache 2.0
     commons-dbcp 1.4: https://github.com/apache/commons-dbcp, Apache 2.0
-    commons-el 1.0: https://mvnrepository.com/artifact/commons-el/commons-el/1.0, Apache 2.0
     commons-email 1.5: https://github.com/apache/commons-email, Apache 2.0
     commons-httpclient 3.0.1: https://mvnrepository.com/artifact/commons-httpclient/commons-httpclient/3.0.1, Apache 2.0
     commons-io 2.4: https://github.com/apache/commons-io, Apache 2.0


### PR DESCRIPTION
## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

## What is the purpose of the pull request

*add Apache 1.1 licenses statistic for commons-el 1.0*

## Brief change log

*add Apache 1.1 licenses statistic for commons-el 1.0*