### PR TITLE
fix 0% UT coverage on new code.  issue #1611

### DIFF
--- a/.github/workflows/ci_ut.yml
+++ b/.github/workflows/ci_ut.yml
@@ -51,17 +51,16 @@ jobs:
           CODECOV_TOKEN="09c2663f-b091-4258-8a47-c981827eb29a" bash <(curl -s https://codecov.io/bash)
       - name: Run SonarCloud analysis
         run: >
-             mvn clean --batch-mode
-             org.jacoco:jacoco-maven-plugin:prepare-agent
-             verify
-             org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
-             -Dsonar.host.url=https://sonarcloud.io
-             -Dsonar.organization=apache
-             -Dsonar.projectKey=apache-dolphinscheduler
-             -Dsonar.login=e4058004bc6be89decf558ac819aa1ecbee57682
+          mvn clean --batch-mode
+          verify
+          org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.1.1688:sonar 
+          -Dsonar.host.url=https://sonarcloud.io
+          -Dsonar.organization=apache
+          -Dsonar.projectKey=apache-dolphinscheduler
+          -Dsonar.login=e4058004bc6be89decf558ac819aa1ecbee57682
         env:
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       - name: Collect logs
         run: |
           mkdir -p ${LOG_DIR}


### PR DESCRIPTION
## What is the purpose of the pull request
Fix SonarCloud 0% UT coverage on new code.  issue #1611

## Brief change log
Changes with maven command :
1. Remove org.jacoco:jacoco-maven-plugin:prepare-agent .
2. Replace  org.sonarsource.scanner.maven:sonar-maven-plugin:sonar to org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.1.1688:sonar .

## Verify this pull request
Report at https://sonarcloud.io/dashboard?id=dolphinscheduler with 13.5% coverage .
![](https://user-images.githubusercontent.com/22913838/71639053-1d8c0700-2caa-11ea-8bc5-96041f2efa13.png)


