### PR TITLE
Supplementary data by schedule

### DIFF
--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/ProcessDao.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/ProcessDao.java
@@ -1454,6 +1454,15 @@ public class ProcessDao {
     }
 
     /**
+     * query Schedule by processDefinitionId
+     * @param processDefinitionId processDefinitionId
+     * @see Schedule
+     */
+    public List<Schedule> queryScheduleByProcessDefinitionId(int processDefinitionId) {
+        return scheduleMapper.queryByProcessDefinitionId(processDefinitionId);
+    }
+
+    /**
      * query need failover process instance
      * @param host host
      * @return process instance list

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ScheduleUtils.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ScheduleUtils.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dolphinscheduler.server.utils;
+
+import org.quartz.impl.triggers.CronTriggerImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.text.ParseException;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * ScheduleUtils
+ */
+public class ScheduleUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(ScheduleUtils.class);
+
+    /**
+     *
+     * @param cron
+     * @return
+     */
+    public static List<Date> getRecentTriggerTime(String cron, int size) {
+        return getRecentTriggerTime(cron, size, new Date(), null);
+    }
+
+    /**
+     *
+     * @param cron
+     * @param size
+     * @param from
+     * @return
+     */
+    public static List<Date> getRecentTriggerTime(String cron, int size, Date from) {
+        return getRecentTriggerTime(cron, size, from, null);
+    }
+
+    /**
+     * Get the execution time of the time interval
+     * @param cron
+     * @param size
+     * @param from
+     * @param to
+     * @return
+     */
+    public static List<Date> getRecentTriggerTime(String cron, int size, Date from, Date to) {
+        List list = new LinkedList<Date>();
+        if(to.before(from)){
+            logger.error("from:{} to:{} error!", from, to);
+            return list;
+        }
+        try {
+            CronTriggerImpl trigger = new CronTriggerImpl();
+            trigger.setCronExpression(cron);
+            trigger.setStartTime(from);
+            if(null != to){
+                trigger.setEndTime(to);
+            }
+            trigger.computeFirstFireTime(null);
+            for (int i = 0; i < size; i++) {
+                Date d = trigger.getNextFireTime();
+                if (d != null) {
+                    if (null != to && d.after(to)) {
+                        break;
+                    }
+                    list.add(d);
+                    trigger.triggered(null);
+                } else {
+                    break;
+                }
+            }
+        } catch (ParseException e) {
+            logger.error("cron:{} error:{}", e.getMessage());
+        }
+        return java.util.Collections.unmodifiableList(list);
+    }
+
+    /**
+     * Get the execution time of the time interval
+     * @param cron
+     * @param from
+     * @param to
+     * @return
+     */
+    public static List<Date> getRecentTriggerTime(String cron, Date from, Date to) {
+        List list = new LinkedList<Date>();
+        if(to.before(from)){
+            logger.error("from:{} to:{} error!", from, to);
+            return list;
+        }
+        try {
+            CronTriggerImpl trigger = new CronTriggerImpl();
+            trigger.setCronExpression(cron);
+            trigger.setStartTime(from);
+            if(null != to){
+                trigger.setEndTime(to);
+            }
+            trigger.computeFirstFireTime(null);
+            for (int i = 0; i < Integer.MAX_VALUE; i++) {
+                Date d = trigger.getNextFireTime();
+                if (d != null) {
+                    if (null != to && d.after(to)) {
+                        break;
+                    }
+                    list.add(d);
+                    trigger.triggered(null);
+                } else {
+                    break;
+                }
+            }
+        } catch (ParseException e) {
+            logger.error("cron:{} error:{}", e.getMessage());
+        }
+        return java.util.Collections.unmodifiableList(list);
+    }
+}

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ScheduleUtils.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ScheduleUtils.java
@@ -33,26 +33,6 @@ public class ScheduleUtils {
     private static final Logger logger = LoggerFactory.getLogger(ScheduleUtils.class);
 
     /**
-     *
-     * @param cron
-     * @return
-     */
-    public static List<Date> getRecentTriggerTime(String cron, int size) {
-        return getRecentTriggerTime(cron, size, new Date(), null);
-    }
-
-    /**
-     *
-     * @param cron
-     * @param size
-     * @param from
-     * @return
-     */
-    public static List<Date> getRecentTriggerTime(String cron, int size, Date from) {
-        return getRecentTriggerTime(cron, size, from, null);
-    }
-
-    /**
      * Get the execution time of the time interval
      * @param cron
      * @param size
@@ -87,7 +67,7 @@ public class ScheduleUtils {
                 }
             }
         } catch (ParseException e) {
-            logger.error("cron:{} error:{}", e.getMessage());
+            logger.error("cron:{} error:{}", cron, e.getMessage());
         }
         return java.util.Collections.unmodifiableList(list);
     }
@@ -126,7 +106,7 @@ public class ScheduleUtils {
                 }
             }
         } catch (ParseException e) {
-            logger.error("cron:{} error:{}", e.getMessage());
+            logger.error("cron:{} error:{}", cron, e.getMessage());
         }
         return java.util.Collections.unmodifiableList(list);
     }

--- a/dolphinscheduler-ui/src/js/conf/home/pages/projects/pages/definition/pages/list/_source/start.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/projects/pages/definition/pages/list/_source/start.vue
@@ -141,7 +141,7 @@
       </div>
       <div class="clearfix list">
         <div class="text">
-          {{$t('Date')}}
+          {{$t('Schedule date')}}
         </div>
         <div class="cont">
           <x-datepicker

--- a/dolphinscheduler-ui/src/js/module/i18n/locale/en_US.js
+++ b/dolphinscheduler-ui/src/js/module/i18n/locale/en_US.js
@@ -361,6 +361,7 @@ export default {
   'Recipient': 'Recipient',
   'Cc': 'Cc',
   'Whether it is a complement process?': 'Whether it is a complement process?',
+  'Schedule date': 'Schedule date',
   'Mode of execution': 'Mode of execution',
   'Serial execution': 'Serial execution',
   'Parallel execution': 'Parallel execution',

--- a/dolphinscheduler-ui/src/js/module/i18n/locale/zh_CN.js
+++ b/dolphinscheduler-ui/src/js/module/i18n/locale/zh_CN.js
@@ -356,6 +356,7 @@ export default {
   'Recipient': '收件人',
   'Cc': '抄送人',
   'Whether it is a complement process?': '是否补数',
+  'Schedule date': '调度日期',
   'Mode of execution': '执行方式',
   'Serial execution': '串行执行',
   'Parallel execution': '并行执行',


### PR DESCRIPTION
## What is the purpose of the pull request
#1550 fix feature: Supplementary data with schedule
Before running, get the schedule of the task and generate task information according to the schedule

## Brief change log
for parallel run
 - edit dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ExecutorService.java

for serial run
 - edit dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterExecThread.java

util
 - edit dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/ProcessDao.java
 - add dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ScheduleUtils.java

ui tips
 - edit dolphinscheduler-ui/src/js/conf/home/pages/projects/pages/definition/pages/list/_source/start.vue
 - edit dolphinscheduler-ui/src/js/module/i18n/locale/en_US.js
 - edit dolphinscheduler-ui/src/js/module/i18n/locale/zh_CN.js

## Verify this pull request
Manually verified the change by testing locally.
