### PR TITLE
Fixed tasks_queue and tasks_kill did not exist in zookeeper #1696

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/queue/TaskQueueZkImpl.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/queue/TaskQueueZkImpl.java
@@ -45,10 +45,10 @@ public class TaskQueueZkImpl implements ITaskQueue {
 
         try {
             String tasksQueuePath = getTasksPath(Constants.DOLPHINSCHEDULER_TASKS_QUEUE);
-            String tasksCancelPath = getTasksPath(Constants.DOLPHINSCHEDULER_TASKS_KILL);
+            String tasksKillPath = getTasksPath(Constants.DOLPHINSCHEDULER_TASKS_KILL);
 
-            for(String key : new String[]{tasksQueuePath,tasksCancelPath}){
-                if(!zookeeperOperator.isExisted(key)){
+            for (String key : new String[]{tasksQueuePath,tasksKillPath}){
+                if (!zookeeperOperator.isExisted(key)){
                     zookeeperOperator.persist(key, "");
                     logger.info("create tasks queue parent node success : {}", key);
                 }
@@ -340,20 +340,20 @@ public class TaskQueueZkImpl implements ITaskQueue {
     public void delete(){
         try {
             String tasksQueuePath = getTasksPath(Constants.DOLPHINSCHEDULER_TASKS_QUEUE);
-            String tasksCancelPath = getTasksPath(Constants.DOLPHINSCHEDULER_TASKS_KILL);
+            String tasksKillPath = getTasksPath(Constants.DOLPHINSCHEDULER_TASKS_KILL);
 
-            for(String taskQueuePath : new String[]{tasksQueuePath,tasksCancelPath}){
-                if(zookeeperOperator.isExisted(taskQueuePath)){
-                    List<String> list = zookeeperOperator.getChildrenKeys(taskQueuePath);
+            for (String key : new String[]{tasksQueuePath,tasksKillPath}){
+                if (zookeeperOperator.isExisted(key)){
+                    List<String> list = zookeeperOperator.getChildrenKeys(key);
                     for (String task : list) {
-                        zookeeperOperator.remove(taskQueuePath + Constants.SINGLE_SLASH + task);
-                        logger.info("delete task from tasks queue : {}/{} ",taskQueuePath,task);
+                        zookeeperOperator.remove(key + Constants.SINGLE_SLASH + task);
+                        logger.info("delete task from tasks queue : {}/{} ", key, task);
                     }
                 }
             }
 
         } catch (Exception e) {
-            logger.error("delete all tasks in tasks queue failure",e);
+            logger.error("delete all tasks in tasks queue failure", e);
         }
     }
 

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/queue/TaskQueueZkImpl.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/queue/TaskQueueZkImpl.java
@@ -37,8 +37,27 @@ public class TaskQueueZkImpl implements ITaskQueue {
 
     private static final Logger logger = LoggerFactory.getLogger(TaskQueueZkImpl.class);
 
+    private final ZookeeperOperator zookeeperOperator;
+
     @Autowired
-    private ZookeeperOperator zookeeperOperator;
+    public TaskQueueZkImpl(ZookeeperOperator zookeeperOperator) {
+        this.zookeeperOperator = zookeeperOperator;
+
+        try {
+            String tasksQueuePath = getTasksPath(Constants.DOLPHINSCHEDULER_TASKS_QUEUE);
+            String tasksCancelPath = getTasksPath(Constants.DOLPHINSCHEDULER_TASKS_KILL);
+
+            for(String key : new String[]{tasksQueuePath,tasksCancelPath}){
+                if(!zookeeperOperator.isExisted(key)){
+                    zookeeperOperator.persist(key, "");
+                    logger.info("create tasks queue parent node success : {}", key);
+                }
+            }
+        } catch (Exception e) {
+            logger.error("create tasks queue parent node failure", e);
+        }
+    }
+
 
     /**
      * get all tasks from tasks queue


### PR DESCRIPTION
## What is the purpose of the pull request

*Fixed the issue that tasks_queue and tasks_kill did not exist in zookeeper*

## Brief change log
  - *Add create tasks node logic to TaskQueueZkImpl.java*
