### PR TITLE
ITaskQueue should have "hasTask" function

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/queue/ITaskQueue.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/queue/ITaskQueue.java
@@ -31,6 +31,13 @@ public interface ITaskQueue {
     List<String> getAllTasks(String key);
 
     /**
+     * check if has a task
+     * @param key queue name
+     * @return true if has; false if not
+     */
+    boolean hasTask(String key);
+
+    /**
      * check task exists in the task queue or not
      *
      * @param key queue name

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/queue/TaskQueueZkImpl.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/queue/TaskQueueZkImpl.java
@@ -75,6 +75,11 @@ public class TaskQueueZkImpl implements ITaskQueue {
         return new ArrayList<>();
     }
 
+    @Override
+    public boolean hasTask(String key) {
+        return zookeeperOperator.hasChildren(key);
+    }
+
     /**
      * check task exists in the task queue or not
      *

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/queue/TaskQueueZkImpl.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/queue/TaskQueueZkImpl.java
@@ -75,9 +75,19 @@ public class TaskQueueZkImpl implements ITaskQueue {
         return new ArrayList<>();
     }
 
+    /**
+     * check if has a task
+     * @param key queue name
+     * @return true if has; false if not
+     */
     @Override
     public boolean hasTask(String key) {
-        return zookeeperOperator.hasChildren(key);
+        try {
+            return zookeeperOperator.hasChildren(key);
+        } catch (Exception e) {
+            logger.error("check has task in tasks queue exception",e);
+        }
+        return false;
     }
 
     /**

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/zk/ZookeeperOperator.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/zk/ZookeeperOperator.java
@@ -141,16 +141,16 @@ public class ZookeeperOperator implements InitializingBean {
     }
 
     public boolean hasChildren(final String key){
+
+        Stat stat ;
         try {
-            Stat stat = zkClient.checkExists().forPath(key);
-            return stat.getNumChildren() >= 1;
-        } catch (InterruptedException ex) {
-            logger.error("hasChildren key : {} InterruptedException", key);
-            throw new IllegalStateException(ex);
+            stat = zkClient.checkExists().forPath(key);
         } catch (Exception ex) {
             logger.error("hasChildren key : {}", key, ex);
             throw new RuntimeException(ex);
         }
+        return stat.getNumChildren() >= 1;
+
     }
 
     public boolean isExisted(final String key) {

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/zk/ZookeeperOperator.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/zk/ZookeeperOperator.java
@@ -141,16 +141,14 @@ public class ZookeeperOperator implements InitializingBean {
     }
 
     public boolean hasChildren(final String key){
-
         Stat stat ;
         try {
             stat = zkClient.checkExists().forPath(key);
+            return stat.getNumChildren() >= 1;
         } catch (Exception ex) {
             logger.error("hasChildren key : {}", key, ex);
             throw new IllegalStateException(ex);
         }
-        return stat.getNumChildren() >= 1;
-
     }
 
     public boolean isExisted(final String key) {

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/zk/ZookeeperOperator.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/zk/ZookeeperOperator.java
@@ -147,7 +147,7 @@ public class ZookeeperOperator implements InitializingBean {
             stat = zkClient.checkExists().forPath(key);
         } catch (Exception ex) {
             logger.error("hasChildren key : {}", key, ex);
-            throw new RuntimeException(ex);
+            throw new IllegalStateException(ex);
         }
         return stat.getNumChildren() >= 1;
 

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/zk/ZookeeperOperator.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/zk/ZookeeperOperator.java
@@ -27,6 +27,7 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
+import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -135,6 +136,19 @@ public class ZookeeperOperator implements InitializingBean {
             throw new IllegalStateException(ex);
         } catch (Exception ex) {
             logger.error("getChildrenKeys key : {}", key, ex);
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public boolean hasChildren(final String key){
+        try {
+            Stat stat = zkClient.checkExists().forPath(key);
+            return stat.getNumChildren() >= 1;
+        } catch (InterruptedException ex) {
+            logger.error("hasChildren key : {} InterruptedException", key);
+            throw new IllegalStateException(ex);
+        } catch (Exception ex) {
+            logger.error("hasChildren key : {}", key, ex);
             throw new RuntimeException(ex);
         }
     }

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/zk/ZookeeperOperator.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/zk/ZookeeperOperator.java
@@ -146,7 +146,6 @@ public class ZookeeperOperator implements InitializingBean {
             stat = zkClient.checkExists().forPath(key);
             return stat.getNumChildren() >= 1;
         } catch (Exception ex) {
-            logger.error("hasChildren key : {}", key, ex);
             throw new IllegalStateException(ex);
         }
     }

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/queue/TaskQueueZKImplTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/queue/TaskQueueZKImplTest.java
@@ -64,7 +64,16 @@ public class TaskQueueZKImplTest extends BaseTaskQueueTest  {
         allTasks = tasksQueue.getAllTasks(Constants.DOLPHINSCHEDULER_TASKS_QUEUE);
         assertEquals(allTasks.size(),0);
     }
-
+    @Test
+    public void hasTask(){
+        init();
+        boolean hasTask = tasksQueue.hasTask(Constants.DOLPHINSCHEDULER_TASKS_QUEUE);
+        assertTrue(hasTask);
+        //delete all
+        tasksQueue.delete();
+        hasTask = tasksQueue.hasTask(Constants.DOLPHINSCHEDULER_TASKS_QUEUE);
+        assertFalse(hasTask);
+    }
     /**
      * test check task exists in the task queue or not
      */

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/runner/FetchTaskThread.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/runner/FetchTaskThread.java
@@ -149,8 +149,9 @@ public class FetchTaskThread implements Runnable{
                 }
 
                 //whether have tasks, if no tasks , no need lock  //get all tasks
-                List<String> tasksQueueList = taskQueue.getAllTasks(Constants.DOLPHINSCHEDULER_TASKS_QUEUE);
-                if (CollectionUtils.isEmpty(tasksQueueList)){
+                boolean hasTask = taskQueue.hasTask(Constants.DOLPHINSCHEDULER_TASKS_QUEUE);
+
+                if (!hasTask){
                     Thread.sleep(Constants.SLEEP_TIME_MILLIS);
                     continue;
                 }


### PR DESCRIPTION
## Background

In FetchTaskThread.run method ,using getAllTasks to determine if there is a task，why not using "hasTask"

## Solution

1、ITaskQueue add "boolean hasTask(String key)" function
2、ZookeeperOperator add “public boolean hasChildren(final String key)” fuction

public boolean hasChildren(final String key){
try {
Stat stat = zkClient.checkExists().forPath(key);
return stat.getNumChildren() >= 1;
} catch (InterruptedException ex) {
logger.error("hasChildren key : {} InterruptedException", key);
throw new IllegalStateException(ex);
} catch (Exception ex) {
logger.error("hasChildren key : {}", key, ex);
throw new RuntimeException(ex);
}
}

> https://github.com/apache/incubator-dolphinscheduler/issues/1742