### PR TITLE
why not invoke checkWorkerGroup in advance 

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/runner/FetchTaskThread.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/runner/FetchTaskThread.java
@@ -186,6 +186,10 @@ public class FetchTaskThread implements Runnable{
                         continue;
                     }
 
+                    if(!checkWorkerGroup(taskInstance, OSUtils.getHost())){
+                        continue;
+                    }
+
                     Tenant tenant = processDao.getTenantForProcess(taskInstance.getProcessInstance().getTenantId(),
                             taskInstance.getProcessDefine().getUserId());
 
@@ -193,10 +197,6 @@ public class FetchTaskThread implements Runnable{
                     if (verifyTenantIsNull(tenant)) {
                         logger.warn("remove task queue : {} due to tenant is null", taskQueueStr);
                         removeNodeFromTaskQueue(taskQueueStr);
-                        continue;
-                    }
-
-                    if(!checkWorkerGroup(taskInstance, OSUtils.getHost())){
                         continue;
                     }
 

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/runner/FetchTaskThread.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/runner/FetchTaskThread.java
@@ -196,17 +196,16 @@ public class FetchTaskThread implements Runnable{
                         continue;
                     }
 
+                    if(!checkWorkerGroup(taskInstance, OSUtils.getHost())){
+                        continue;
+                    }
+
                     // set queue for process instance, user-specified queue takes precedence over tenant queue
                     String userQueue = processDao.queryUserQueueByProcessInstanceId(taskInstance.getProcessInstanceId());
                     taskInstance.getProcessInstance().setQueue(StringUtils.isEmpty(userQueue) ? tenant.getQueue() : userQueue);
                     taskInstance.getProcessInstance().setTenantCode(tenant.getTenantCode());
 
                     logger.info("worker fetch taskId : {} from queue ", taskInstId);
-
-
-                    if(!checkWorkerGroup(taskInstance, OSUtils.getHost())){
-                        continue;
-                    }
 
                     // local execute path
                     String execLocalPath = getExecLocalPath();


### PR DESCRIPTION
## Background

In FetchTaskThread.run method, checkWorkerGroup invoke after "queryUserQueueByProcessInstanceId", why not just after getTaskInstanceDetailByTaskId

if checkWorkerGroup check failed , the rest of the logic can be ignored
## Solution

checkWorkerGroup invoked after getTaskInstanceDetailByTaskId

                if (verifyTaskInstanceIsNull(taskInstance)) {
                    logger.warn("remove task queue : {} due to taskInstance is null", taskQueueStr);
                    removeNodeFromTaskQueue(taskQueueStr);
                    continue;
                }

                if(!checkWorkerGroup(taskInstance, OSUtils.getHost())){
                    continue;
                }

> https://github.com/apache/incubator-dolphinscheduler/issues/1743