### PR TITLE
Supplementary data by schedule

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ExecutorService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ExecutorService.java
@@ -501,7 +501,7 @@ public class ExecutorService extends BaseService{
 
         if(commandType == CommandType.COMPLEMENT_DATA){
             runMode = (runMode == null) ? RunMode.RUN_MODE_SERIAL : runMode;
-            if(null != start && null != end && end.before(start)){
+            if(null != start && null != end && start.before(end)){
                 if(runMode == RunMode.RUN_MODE_SERIAL){
                     cmdParam.put(CMDPARAM_COMPLEMENT_DATA_START_DATE, DateUtils.dateToString(start));
                     cmdParam.put(CMDPARAM_COMPLEMENT_DATA_END_DATE, DateUtils.dateToString(end));

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ExecutorService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ExecutorService.java
@@ -21,6 +21,7 @@ import org.apache.dolphinscheduler.api.enums.ExecuteType;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.*;
+import org.apache.dolphinscheduler.common.utils.CollectionUtils;
 import org.apache.dolphinscheduler.common.utils.DateUtils;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.common.utils.StringUtils;
@@ -29,6 +30,7 @@ import org.apache.dolphinscheduler.dao.entity.*;
 import org.apache.dolphinscheduler.dao.mapper.ProcessDefinitionMapper;
 import org.apache.dolphinscheduler.dao.mapper.ProcessInstanceMapper;
 import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
+import org.apache.dolphinscheduler.server.utils.ScheduleUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -505,16 +507,36 @@ public class ExecutorService extends BaseService{
                 command.setCommandParam(JSONUtils.toJson(cmdParam));
                 return processDao.createCommand(command);
             }else if (runMode == RunMode.RUN_MODE_PARALLEL){
-                int runCunt = 0;
-                while(!start.after(end)){
-                    runCunt += 1;
-                    cmdParam.put(CMDPARAM_COMPLEMENT_DATA_START_DATE, DateUtils.dateToString(start));
-                    cmdParam.put(CMDPARAM_COMPLEMENT_DATA_END_DATE, DateUtils.dateToString(start));
-                    command.setCommandParam(JSONUtils.toJson(cmdParam));
-                    processDao.createCommand(command);
-                    start = DateUtils.getSomeDay(start, 1);
+                List<Schedule> schedules = processDao.queryReleaseSchedulerListByProcessDefinitionId(processDefineId);
+                List<Date> listDate = new LinkedList<>();
+                if(!CollectionUtils.isEmpty(schedules)){
+                    for (Schedule item : schedules) {
+                        List<Date> list = ScheduleUtils.getRecentTriggerTime(item.getCrontab(), start, end);
+                        listDate.addAll(list);
+                    }
                 }
-                return runCunt;
+                if(!CollectionUtils.isEmpty(listDate)){
+                    // loop by schedule date
+                    for (Date date : listDate) {
+                        cmdParam.put(CMDPARAM_COMPLEMENT_DATA_START_DATE, DateUtils.dateToString(date));
+                        cmdParam.put(CMDPARAM_COMPLEMENT_DATA_END_DATE, DateUtils.dateToString(date));
+                        command.setCommandParam(JSONUtils.toJson(cmdParam));
+                        processDao.createCommand(command);
+                    }
+                    return listDate.size();
+                }else{
+                    // loop by day
+                    int runCunt = 0;
+                    while(!start.after(end)) {
+                        runCunt += 1;
+                        cmdParam.put(CMDPARAM_COMPLEMENT_DATA_START_DATE, DateUtils.dateToString(start));
+                        cmdParam.put(CMDPARAM_COMPLEMENT_DATA_END_DATE, DateUtils.dateToString(start));
+                        command.setCommandParam(JSONUtils.toJson(cmdParam));
+                        processDao.createCommand(command);
+                        start = DateUtils.getSomeDay(start, 1);
+                    }
+                    return runCunt;
+                }
             }
         }else{
             command.setCommandParam(JSONUtils.toJson(cmdParam));

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ExecutorService2Test.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ExecutorService2Test.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dolphinscheduler.api.service;
+
+import org.apache.dolphinscheduler.api.enums.Status;
+import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.common.enums.CommandType;
+import org.apache.dolphinscheduler.common.enums.Priority;
+import org.apache.dolphinscheduler.common.enums.ReleaseState;
+import org.apache.dolphinscheduler.common.enums.RunMode;
+import org.apache.dolphinscheduler.dao.ProcessDao;
+import org.apache.dolphinscheduler.dao.entity.*;
+import org.apache.dolphinscheduler.dao.mapper.ProcessDefinitionMapper;
+import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.text.ParseException;
+import java.util.*;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class ExecutorService2Test {
+
+    @InjectMocks
+    private ExecutorService executorService;
+
+    @Mock
+    private ProcessDao processDao;
+
+    @Mock
+    private ProcessDefinitionMapper processDefinitionMapper;
+
+    @Mock
+    private ProjectMapper projectMapper;
+
+    @Mock
+    private ProjectService projectService;
+
+    private int processDefinitionId = 1;
+
+    private int tenantId = 1;
+
+    private int userId = 1;
+
+    private ProcessDefinition processDefinition = new ProcessDefinition();
+
+    private User loginUser = new User();
+
+    private String projectName = "projectName";
+
+    private Project project = new Project();
+
+    private String cronTime;
+
+    @Before
+    public void init(){
+        // user
+        loginUser.setId(userId);
+
+        // processDefinition
+        processDefinition.setId(processDefinitionId);
+        processDefinition.setReleaseState(ReleaseState.ONLINE);
+        processDefinition.setTenantId(tenantId);
+        processDefinition.setUserId(userId);
+
+        // project
+        project.setName(projectName);
+
+        // cronRangeTime
+        cronTime = "2020-01-01 00:00:00,2020-01-31 23:00:00";
+
+        // mock
+        Mockito.when(projectMapper.queryByName(projectName)).thenReturn(project);
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(checkProjectAndAuth());
+        Mockito.when(processDefinitionMapper.selectById(processDefinitionId)).thenReturn(processDefinition);
+        Mockito.when(processDao.getTenantForProcess(tenantId, userId)).thenReturn(new Tenant());
+        Mockito.when(processDao.createCommand(any(Command.class))).thenReturn(1);
+    }
+
+    /**
+     * serial
+     * @throws ParseException
+     */
+    @Test
+    public void testSerial() throws ParseException {
+        try {
+            Mockito.when(processDao.queryReleaseSchedulerListByProcessDefinitionId(processDefinitionId)).thenReturn(zeroSchedulerList());
+            Map<String, Object> result = executorService.execProcessInstance(loginUser, projectName,
+                    processDefinitionId, cronTime, CommandType.COMPLEMENT_DATA,
+                    null, null,
+                    null, null, 0,
+                    "", "", RunMode.RUN_MODE_SERIAL,
+                    Priority.LOW, 0, 110);
+            Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+            verify(processDao, times(1)).createCommand(any(Command.class));
+        }catch (Exception e){
+            Assert.assertTrue(false);
+        }
+    }
+
+    /**
+     * without schedule
+     * @throws ParseException
+     */
+    @Test
+    public void testParallelWithOutSchedule() throws ParseException {
+        try{
+            Mockito.when(processDao.queryReleaseSchedulerListByProcessDefinitionId(processDefinitionId)).thenReturn(zeroSchedulerList());
+            Map<String, Object> result = executorService.execProcessInstance(loginUser, projectName,
+                    processDefinitionId, cronTime, CommandType.COMPLEMENT_DATA,
+                    null, null,
+                    null, null, 0,
+                    "", "", RunMode.RUN_MODE_PARALLEL,
+                    Priority.LOW, 0, 110);
+            Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+            verify(processDao, times(31)).createCommand(any(Command.class));
+        }catch (Exception e){
+            Assert.assertTrue(false);
+        }
+    }
+
+    /**
+     * with schedule
+     * @throws ParseException
+     */
+    @Test
+    public void testParallelWithSchedule() throws ParseException {
+        try{
+            Mockito.when(processDao.queryReleaseSchedulerListByProcessDefinitionId(processDefinitionId)).thenReturn(oneSchedulerList());
+            Map<String, Object> result = executorService.execProcessInstance(loginUser, projectName,
+                    processDefinitionId, cronTime, CommandType.COMPLEMENT_DATA,
+                    null, null,
+                    null, null, 0,
+                    "", "", RunMode.RUN_MODE_PARALLEL,
+                    Priority.LOW, 0, 110);
+            Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+            verify(processDao, times(16)).createCommand(any(Command.class));
+        }catch (Exception e){
+            Assert.assertTrue(false);
+        }
+    }
+
+    private List<Schedule> zeroSchedulerList(){
+        return Collections.EMPTY_LIST;
+    }
+
+    private List<Schedule> oneSchedulerList(){
+        List<Schedule> schedulerList = new LinkedList<>();
+        Schedule schedule = new Schedule();
+        schedule.setCrontab("0 0 0 1/2 * ?");
+        schedulerList.add(schedule);
+        return schedulerList;
+    }
+
+    private Map<String, Object> checkProjectAndAuth(){
+        Map<String, Object> result = new HashMap<>();
+        result.put(Constants.STATUS, Status.SUCCESS);
+        return result;
+    }
+}

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/ProcessDao.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/ProcessDao.java
@@ -1461,6 +1461,15 @@ public class ProcessDao {
     }
 
     /**
+     * query Schedule by processDefinitionId
+     * @param processDefinitionId processDefinitionId
+     * @see Schedule
+     */
+    public List<Schedule> queryReleaseSchedulerListByProcessDefinitionId(int processDefinitionId) {
+        return scheduleMapper.queryReleaseSchedulerListByProcessDefinitionId(processDefinitionId);
+    }
+
+    /**
      * query need failover process instance
      * @param host host
      * @return process instance list

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/ScheduleMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/ScheduleMapper.java
@@ -60,4 +60,11 @@ public interface ScheduleMapper extends BaseMapper<Schedule> {
      */
     List<Schedule> queryByProcessDefinitionId(@Param("processDefinitionId") int processDefinitionId);
 
+    /**
+     * query schedule list by process definition id
+     * @param processDefinitionId
+     * @return
+     */
+    List<Schedule> queryReleaseSchedulerListByProcessDefinitionId(@Param("processDefinitionId") int processDefinitionId);
+
 }

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ScheduleMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ScheduleMapper.xml
@@ -55,4 +55,9 @@
         from t_ds_schedules
         where process_definition_id =#{processDefinitionId}
     </select>
+    <select id="queryReleaseSchedulerListByProcessDefinitionId" resultType="org.apache.dolphinscheduler.dao.entity.Schedule">
+        select *
+        from t_ds_schedules
+        where process_definition_id =#{processDefinitionId} and release_state = 1
+    </select>
 </mapper>

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterExecThread.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterExecThread.java
@@ -227,10 +227,9 @@ public class MasterExecThread implements Runnable {
             processDao.updateProcessInstance(processInstance);
         }else{
             scheduleDate = processInstance.getScheduleTime();
-        }
-
-        if(scheduleDate == null){
-            scheduleDate = startDate;
+            if(scheduleDate == null){
+                scheduleDate = startDate;
+            }
         }
 
         while(Stopper.isRunning()){

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ScheduleUtils.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ScheduleUtils.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dolphinscheduler.server.utils;
+
+import org.quartz.impl.triggers.CronTriggerImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.text.ParseException;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * ScheduleUtils
+ */
+public class ScheduleUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(ScheduleUtils.class);
+
+    /**
+     * Get the execution time of the time interval
+     * @param cron
+     * @param from
+     * @param to
+     * @return
+     */
+    public static List<Date> getRecentTriggerTime(String cron, Date from, Date to) {
+        return getRecentTriggerTime(cron, Integer.MAX_VALUE, from, to);
+    }
+
+    /**
+     * Get the execution time of the time interval
+     * @param cron
+     * @param size
+     * @param from
+     * @param to
+     * @return
+     */
+    public static List<Date> getRecentTriggerTime(String cron, int size, Date from, Date to) {
+        List list = new LinkedList<Date>();
+        if(to.before(from)){
+            logger.error("schedule date from:{} must before date to:{}!", from, to);
+            return list;
+        }
+        try {
+            CronTriggerImpl trigger = new CronTriggerImpl();
+            trigger.setCronExpression(cron);
+            trigger.setStartTime(from);
+            trigger.setEndTime(to);
+            trigger.computeFirstFireTime(null);
+            for (int i = 0; i < size; i++) {
+                Date schedule = trigger.getNextFireTime();
+                if(null == schedule){
+                    break;
+                }
+                list.add(schedule);
+                trigger.triggered(null);
+            }
+        } catch (ParseException e) {
+            logger.error("cron:{} error:{}", e.getMessage());
+        }
+        return java.util.Collections.unmodifiableList(list);
+    }
+}

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ScheduleUtils.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ScheduleUtils.java
@@ -72,7 +72,7 @@ public class ScheduleUtils {
                 trigger.triggered(null);
             }
         } catch (ParseException e) {
-            logger.error("cron:{} error:{}", e.getMessage());
+            logger.error("cron:{} error:{}", cron, e.getMessage());
         }
         return java.util.Collections.unmodifiableList(list);
     }

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/utils/ScheduleUtilsTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/utils/ScheduleUtilsTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.server.utils;
+
+import org.apache.dolphinscheduler.common.utils.DateUtils;
+import org.junit.Test;
+import java.util.Date;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test ScheduleUtils
+ */
+public class ScheduleUtilsTest {
+
+    /**
+     * Test the getRecentTriggerTime method
+     */
+    @Test
+    public void testGetRecentTriggerTime() {
+        Date from = DateUtils.stringToDate("2020-01-01 00:00:00");
+        Date to = DateUtils.stringToDate("2020-01-31 01:00:00");
+        // test date
+        assertEquals(0, ScheduleUtils.getRecentTriggerTime("0 0 0 * * ? ", to, from).size());
+        // test error cron
+        assertEquals(0, ScheduleUtils.getRecentTriggerTime("0 0 0 * *", from, to).size());
+        // test cron
+        assertEquals(31, ScheduleUtils.getRecentTriggerTime("0 0 0 * * ? ", from, to).size());
+    }
+}

--- a/dolphinscheduler-ui/src/js/conf/home/pages/projects/pages/definition/pages/list/_source/start.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/projects/pages/definition/pages/list/_source/start.vue
@@ -141,7 +141,7 @@
       </div>
       <div class="clearfix list">
         <div class="text">
-          {{$t('Date')}}
+          {{$t('Schedule date')}}
         </div>
         <div class="cont">
           <x-datepicker

--- a/dolphinscheduler-ui/src/js/module/i18n/locale/en_US.js
+++ b/dolphinscheduler-ui/src/js/module/i18n/locale/en_US.js
@@ -361,6 +361,7 @@ export default {
   'Recipient': 'Recipient',
   'Cc': 'Cc',
   'Whether it is a complement process?': 'Whether it is a complement process?',
+  'Schedule date': 'Schedule date',
   'Mode of execution': 'Mode of execution',
   'Serial execution': 'Serial execution',
   'Parallel execution': 'Parallel execution',

--- a/dolphinscheduler-ui/src/js/module/i18n/locale/zh_CN.js
+++ b/dolphinscheduler-ui/src/js/module/i18n/locale/zh_CN.js
@@ -356,6 +356,7 @@ export default {
   'Recipient': '收件人',
   'Cc': '抄送人',
   'Whether it is a complement process?': '是否补数',
+  'Schedule date': '调度日期',
   'Mode of execution': '执行方式',
   'Serial execution': '串行执行',
   'Parallel execution': '并行执行',

--- a/pom.xml
+++ b/pom.xml
@@ -694,6 +694,7 @@
 						<include>**/api/service/ProcessDefinitionServiceTest.java</include>
 						<include>**/api/service/UdfFuncServiceTest.java</include>
 						<include>**/api/service/ResourcesServiceTest.java</include>
+						<include>**/api/service/ExecutorService2Test.java</include>
 						<include>**/alert/utils/ExcelUtilsTest.java</include>
 						<include>**/alert/utils/FuncUtilsTest.java</include>
 						<include>**/alert/utils/JSONUtilsTest.java</include>
@@ -701,6 +702,7 @@
 						<include>**/server/utils/SparkArgsUtilsTest.java</include>
 						<include>**/server/utils/FlinkArgsUtilsTest.java</include>
 						<include>**/server/utils/ParamUtilsTest.java</include>
+						<include>**/server/utils/ScheduleUtilsTest.java</include>
 						<include>**/dao/mapper/AccessTokenMapperTest.java</include>
 						<include>**/dao/mapper/AlertGroupMapperTest.java</include>
 						<include>**/dao/mapper/AlertMapperTest.java</include>


### PR DESCRIPTION
## What is the purpose of the pull request
#1550 fix feature: Supplementary data with schedule
When the task complement is run, a execution plan list is generated according to the scheduling plan. If the execution plan list is not empty, it is scheduled according to the plan list. If the execution plan is empty, it is executed daily.

## Brief change log
for parallel run
 - edit dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ExecutorService.java

for serial run
 - edit dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterExecThread.java

dao
 - edit dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/ProcessDao.java
 - edit dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/ScheduleMapper.java
 - edit dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ScheduleMapper.xml

util
 - add dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ScheduleUtils.java

ui
 - edit dolphinscheduler-ui/src/js/conf/home/pages/projects/pages/definition/pages/list/_source/start.vue
 - edit dolphinscheduler-ui/src/js/module/i18n/locale/en_US.js
 - edit dolphinscheduler-ui/src/js/module/i18n/locale/zh_CN.js

## Verify this pull request
Manually verified the change by testing locally.