### PR TITLE
fix: get taskAppId bug

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractCommandExecutor.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/AbstractCommandExecutor.java
@@ -147,9 +147,6 @@ public abstract class AbstractCommandExecutor {
             // get process id
             int pid = getProcessId(process);
 
-            // task instance id
-            int taskInstId = Integer.parseInt(taskAppId.split("_")[2]);
-
             processDao.updatePidByTaskInstId(taskInstId, pid, "");
 
             logger.info("process start, process id is: {}", pid);


### PR DESCRIPTION
The constructor has passed in an taskAppId, no need to get from taskAppId.

```
public AbstractCommandExecutor(Consumer<List<String>> logHandler,
                                   String taskDir, String taskAppId,int taskInstId,String tenantCode, String envFile,
                                   Date startTime, int timeout, Logger logger){
        this.logHandler = logHandler;
        this.taskDir = taskDir;
        this.taskAppId = taskAppId;
        this.taskInstId = taskInstId;
        this.tenantCode = tenantCode;
```