### PR TITLE
[newfeature] Add input cache for datax task and codemirror component

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/datax.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/datax.vue
@@ -232,6 +232,8 @@
        * Processing code highlighting
        */
       _handlerEditor () {
+        this._destroyEditor()
+
         // editor
         editor = codemirror('code-sql-mirror', {
           mode: 'sql',
@@ -249,9 +251,34 @@
         // Monitor keyboard
         editor.on('keypress', this.keypress)
 
+        editor.on('changes', () => {
+          this._cacheParams()
+        })
+
         editor.setValue(this.sql)
 
         return editor
+      },
+      _cacheParams () {
+        this.$emit('on-cache-params', {
+          dsType: this.dsType,
+          dataSource: this.rtDatasource,
+          dtType: this.dtType,
+          dataTarget: this.rtDatatarget,
+          sql: editor?editor.getValue():'',
+          targetTable: this.targetTable,
+          jobSpeedByte: this.jobSpeedByte * 1024,
+          jobSpeedRecord: this.jobSpeedRecord,
+          preStatements: this.preStatements,
+          postStatements: this.postStatements
+        });
+      },
+      _destroyEditor () {
+         if (editor) {
+          editor.toTextArea() // Uninstall
+          editor.off($('.code-sql-mirror'), 'keypress', this.keypress)
+          editor.off($('.code-sql-mirror'), 'changes', this.changes)
+        }
       }
     },
     created () {
@@ -286,7 +313,27 @@
         editor.off($('.code-sql-mirror'), 'keypress', this.keypress)
       }
     },
-    computed: {},
+    watch: {
+      //Watch the cacheParams
+      cacheParams (val) {
+        this._cacheParams();
+      }
+    },
+    computed: {
+      cacheParams () {
+        return {
+          dsType: this.dsType,
+          dataSource: this.rtDatasource,
+          dtType: this.dtType,
+          dataTarget: this.rtDatatarget,
+          targetTable: this.targetTable,
+          jobSpeedByte: this.jobSpeedByte * 1024,
+          jobSpeedRecord: this.jobSpeedRecord,
+          preStatements: this.preStatements,
+          postStatements: this.postStatements
+        }
+      }
+    },
     components: { mListBox, mDatasource, mLocalParams, mStatementList, mSelectInput }
   }
 </script>

--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/python.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/python.vue
@@ -129,6 +129,8 @@
        * Processing code highlighting
        */
       _handlerEditor () {
+        this._destroyEditor()
+
         // editor
         editor = codemirror('code-python-mirror', {
           mode: 'python',
@@ -143,26 +145,45 @@
           }
         }
 
+        this.changes = () => {
+          this._cacheParams()
+        }
+
         // Monitor keyboard
         editor.on('keypress', this.keypress)
+
+        editor.on('changes', this.changes)
 
         editor.setValue(this.rawScript)
 
         return editor
+      },
+      _cacheParams () {
+        this.$emit('on-cache-params', {
+          resourceList: this.cacheResourceList,
+          localParams: this.localParams,
+          rawScript: editor ? editor.getValue() : ''
+        });
+      },
+      _destroyEditor () {
+         if (editor) {
+          editor.toTextArea() // Uninstall
+          editor.off($('.code-python-mirror'), 'keypress', this.keypress)
+          editor.off($('.code-python-mirror'), 'changes', this.changes)
+        }
       }
     },
     watch: {
       //Watch the cacheParams
       cacheParams (val) {
-        this.$emit('on-cache-params', val);
+        this._cacheParams()
       }
     },
     computed: {
       cacheParams () {
         return {
           resourceList: this.cacheResourceList,
-          localParams: this.localParams,
-          rawScript: editor ? editor.getValue() : ''
+          localParams: this.localParams
         }
       }
     },
@@ -193,8 +214,11 @@
       }, 200)
     },
     destroyed () {
-      editor.toTextArea() // Uninstall
-      editor.off($('.code-python-mirror'), 'keypress', this.keypress)
+      if (editor) {
+        editor.toTextArea() // Uninstall
+        editor.off($('.code-python-mirror'), 'keypress', this.keypress)
+        editor.off($('.code-python-mirror'), 'changes', this.changes)
+      }
     },
     components: { mLocalParams, mListBox, mResources }
   }

--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/shell.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/shell.vue
@@ -163,6 +163,8 @@
        * Processing code highlighting
        */
       _handlerEditor () {
+        this._destroyEditor()
+
         // editor
         editor = codemirror('code-shell-mirror', {
           mode: 'shell',
@@ -177,25 +179,45 @@
           }
         }
 
+        this.changes = () => {
+          this._cacheParams()
+        }
+
         // Monitor keyboard
         editor.on('keypress', this.keypress)
+
+        editor.on('changes', this.changes)
+
         editor.setValue(this.rawScript)
 
         return editor
+      },
+      _cacheParams () {
+        this.$emit('on-cache-params', {
+          resourceList: this.cacheResourceList,
+          localParams: this.localParams,
+          rawScript: editor ? editor.getValue() : ''
+        });
+      },
+      _destroyEditor () {
+         if (editor) {
+          editor.toTextArea() // Uninstall
+          editor.off($('.code-sql-mirror'), 'keypress', this.keypress)
+          editor.off($('.code-sql-mirror'), 'changes', this.changes)
+        }
       }
     },
     watch: {
       //Watch the cacheParams
       cacheParams (val) {
-        this.$emit('on-cache-params', val);
+        this._cacheParams()
       }
     },
     computed: {
       cacheParams () {
         return {
           resourceList: this.cacheResourceList,
-          localParams: this.localParams,
-          rawScript: editor ? editor.getValue() : ''
+          localParams: this.localParams
         }
       }
     },
@@ -229,6 +251,7 @@
       if (editor) {
         editor.toTextArea() // Uninstall
         editor.off($('.code-shell-mirror'), 'keypress', this.keypress)
+        editor.off($('.code-shell-mirror'), 'changes', this.changes)
       }
     },
     components: { mLocalParams, mListBox, mResources, mScriptBox }


### PR DESCRIPTION
## What is the purpose of the pull request

1. add input cache for datax task
2. add cache for codemirror component which include python, shell and sql task.

## Brief change log

  - *datax.vue*
  - *python.vue*
  - *shell.vue*
  - *sql.vue*

## Verify this pull request

This change added tests and can be verified as follows:

  - *Manually verified the change by testing locally.*
