### PR TITLE
Upgrade curator version

### DIFF
--- a/dolphinscheduler-api/pom.xml
+++ b/dolphinscheduler-api/pom.xml
@@ -140,6 +140,12 @@
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-recipes</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- hadoop -->

--- a/dolphinscheduler-server/pom.xml
+++ b/dolphinscheduler-server/pom.xml
@@ -86,6 +86,12 @@
 		<dependency>
 			<groupId>org.apache.curator</groupId>
 			<artifactId>curator-recipes</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.zookeeper</groupId>
+					<artifactId>zookeeper</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.zookeeper</groupId>

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/zk/DefaultEnsembleProvider.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/zk/DefaultEnsembleProvider.java
@@ -45,4 +45,14 @@ public class DefaultEnsembleProvider implements EnsembleProvider {
     public void close() throws IOException {
         //NOP
     }
+
+    @Override
+    public void setConnectionString(String connectionString) {
+        //NOP
+    }
+
+    @Override
+    public boolean updateServerListEnabled() {
+        return false;
+    }
 }

--- a/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/zk/DefaultEnsembleProviderTest.java
+++ b/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/zk/DefaultEnsembleProviderTest.java
@@ -1,0 +1,49 @@
+package org.apache.dolphinscheduler.service.zk;
+
+import org.apache.curator.ensemble.EnsembleProvider;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+public class DefaultEnsembleProviderTest {
+    private static final String DEFAULT_SERVER_LIST = "localhost:2181";
+
+    @Test
+    public void startAndClose() {
+        EnsembleProvider ensembleProvider = new DefaultEnsembleProvider(DEFAULT_SERVER_LIST);
+        try {
+            ensembleProvider.start();
+        } catch (Exception e) {
+            Assert.fail("EnsembleProvider start error: " + e.getMessage());
+        }
+        try {
+            ensembleProvider.close();
+        } catch (IOException e) {
+            Assert.fail("EnsembleProvider close error: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void getConnectionString() {
+        EnsembleProvider ensembleProvider = new DefaultEnsembleProvider(DEFAULT_SERVER_LIST);
+        Assert.assertEquals(DEFAULT_SERVER_LIST, ensembleProvider.getConnectionString());
+    }
+
+    @Test
+    public void setConnectionString() {
+        EnsembleProvider ensembleProvider = new DefaultEnsembleProvider(DEFAULT_SERVER_LIST);
+        ensembleProvider.setConnectionString("otherHost:2181");
+        Assert.assertEquals(DEFAULT_SERVER_LIST, ensembleProvider.getConnectionString());
+    }
+
+    @Test
+    public void updateServerListEnabled() {
+        EnsembleProvider ensembleProvider = new DefaultEnsembleProvider(DEFAULT_SERVER_LIST);
+        Assert.assertFalse(ensembleProvider.updateServerListEnabled());
+    }
+}

--- a/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/zk/DefaultEnsembleProviderTest.java
+++ b/dolphinscheduler-service/src/test/java/org/apache/dolphinscheduler/service/zk/DefaultEnsembleProviderTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dolphinscheduler.service.zk;
 
 import org.apache.curator.ensemble.EnsembleProvider;

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <curator.version>2.12.0</curator.version>
+        <curator.version>4.3.0</curator.version>
         <spring.version>5.1.5.RELEASE</spring.version>
         <spring.boot.version>2.1.3.RELEASE</spring.boot.version>
         <java.version>1.8</java.version>
@@ -251,6 +251,12 @@
                 <groupId>org.apache.curator</groupId>
                 <artifactId>curator-recipes</artifactId>
                 <version>${curator.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.zookeeper</groupId>
+                        <artifactId>zookeeper</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -736,6 +736,7 @@
                         <include>**/server/worker/task/datax/DataxTaskTest.java</include>
                         <include>**/server/worker/task/sqoop/SqoopTaskTest.java</include>
                         <include>**/server/utils/DataxUtilsTest.java</include>
+                        <include>**/service/zk/DefaultEnsembleProviderTest.java</include>
                     </includes>
                     <!-- <skip>true</skip> -->
                 </configuration>


### PR DESCRIPTION
https://github.com/apache/incubator-dolphinscheduler/issues/2020

the curator issue: https://github.com/apache/curator/pull/297  may cause InterProcessMutex.acquire() hang, we'd better upgrade its version
