### PR TITLE
fix: remove redundant import class #2109

### DIFF
--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/Command.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/Command.java
@@ -16,8 +16,6 @@
  */
 package org.apache.dolphinscheduler.remote.command;
 
-import com.sun.org.apache.regexp.internal.RE;
-
 import java.io.Serializable;
 import java.util.concurrent.atomic.AtomicLong;
 


### PR DESCRIPTION
Command.java

`import com.sun.org.apache.regexp.internal.RE;`

The class is unused and cannot be built in jdk11.