### PR TITLE
access field handle of FileDescriptor in ProcessImplForWin32 by reflection for portability

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/OSUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/OSUtils.java
@@ -400,8 +400,7 @@ public class OSUtils {
    * @return true if mac
    */
   public static boolean isMacOS() {
-    String os = System.getProperty("os.name");
-    return os.startsWith("Mac");
+    return getOSName().startsWith("Mac");
   }
 
 
@@ -409,9 +408,16 @@ public class OSUtils {
    * whether is windows
    * @return true if windows
    */
-  public static boolean isWindows() {
-    String os = System.getProperty("os.name");
-    return os.startsWith("Windows");
+  public static boolean isWindows() { ;
+    return getOSName().startsWith("Windows");
+  }
+
+  /**
+   * get current OS name
+   * @return current OS name
+   */
+  public static String getOSName() {
+    return System.getProperty("os.name");
   }
 
   /**

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/process/ProcessImplForWin32.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/process/ProcessImplForWin32.java
@@ -20,6 +20,7 @@ import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.*;
 import com.sun.jna.ptr.IntByReference;
 import java.lang.reflect.Field;
+import org.apache.dolphinscheduler.common.utils.OSUtils;
 import sun.security.action.GetPropertyAction;
 
 import java.io.*;
@@ -32,14 +33,20 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static com.sun.jna.platform.win32.WinBase.STILL_ACTIVE;
+import static java.util.Objects.requireNonNull;
 
 public class ProcessImplForWin32 extends Process {
 
     private static final Field FD_HANDLE;
 
     static {
+        if (!OSUtils.isWindows()) {
+            throw new RuntimeException("ProcessImplForWin32 can be only initialized in " +
+                    "Windows environment, but current OS is " + OSUtils.getOSName());
+        }
+
         try {
-            FD_HANDLE = FileDescriptor.class.getDeclaredField("handle");
+            FD_HANDLE = requireNonNull(FileDescriptor.class.getDeclaredField("handle"));
             FD_HANDLE.setAccessible(true);
         } catch (NoSuchFieldException e) {
             throw new RuntimeException(e);

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/worker/task/shell/ShellTaskTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/worker/task/shell/ShellTaskTest.java
@@ -27,6 +27,7 @@ import org.apache.dolphinscheduler.service.bean.SpringApplicationContext;
 import org.apache.dolphinscheduler.service.process.ProcessService;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -172,7 +173,7 @@ public class ShellTaskTest {
     @Test
     public void testHandleForWindows() throws Exception {
         try {
-            PowerMockito.when(OSUtils.isWindows()).thenReturn(true);
+            Assume.assumeTrue(OSUtils.isWindows());
             shellTask.handle();
             Assert.assertTrue(true);
         } catch (Error | Exception e) {


### PR DESCRIPTION
## What is the purpose of the pull request

Current implementation relies on `sun.misc.JavaIOFileDescriptorAccess`
which is only accessible on oraclejdk8.

Basically the demand is getting & setting `handle` field of `FileDescriptor`,
so we can directly do that with reflection.

Though, I suspect the necessity we introduce ProcessImplForWin32. Maybe
we could have a better way to support worker server to run bat script.

## Brief change log

Replace `JavaIOFileDescriptorAccess` with reflections to `FileDescriptor`.

## Verify this pull request

This pull request is already covered by existing tests, such as

- `ProcessImplForWin32Test`

This closes #2111 .