### PR TITLE
docker run failed when docker command was `docker run -d`

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -23,11 +23,11 @@ ENV TZ Asia/Shanghai
 ENV LANG C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
 
-#1. install dos2unix shadow bash openrc python sudo vim wget iputils net-tools ssh pip kazoo.
+#1. install dos2unix shadow bash openrc python sudo vim wget iputils net-tools ssh pip tini kazoo.
 #If install slowly, you can replcae alpine's mirror with aliyun's mirror, Example:
 #RUN sed -i "s/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g" /etc/apk/repositories
 RUN apk update && \
-    apk add dos2unix shadow bash openrc python sudo vim wget iputils net-tools openssh-server py2-pip && \
+    apk add dos2unix shadow bash openrc python sudo vim wget iputils net-tools openssh-server py2-pip tini && \
     apk add --update procps && \
     openrc boot && \
     pip install kazoo
@@ -92,4 +92,4 @@ RUN rm -rf /var/cache/apk/*
 #9. expose port
 EXPOSE 2181 2888 3888 5432 12345 50051 8888
 
-ENTRYPOINT ["/root/startup.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "/root/startup.sh"]

--- a/dockerfile/hooks/check
+++ b/dockerfile/hooks/check
@@ -17,7 +17,7 @@
 #
 echo "------ dolphinscheduler check - server - status -------"
 sleep 20
-server_num=$(docker top `docker container list | grep startup | awk '{print $1}'`| grep java | grep "dolphinscheduler" | awk -F 'classpath ' '{print $2}' | awk '{print $2}' | sort | uniq -c | wc -l)
+server_num=$(docker top `docker container list | grep '/sbin/tini' | awk '{print $1}'`| grep java | grep "dolphinscheduler" | awk -F 'classpath ' '{print $2}' | awk '{print $2}' | sort | uniq -c | wc -l)
 if [ $server_num -eq 5 ]
 then
     echo "Server all start successfully"

--- a/dockerfile/startup.sh
+++ b/dockerfile/startup.sh
@@ -188,6 +188,9 @@ case "$1" in
     ;;
 esac
 
+# init directories and log files
+mkdir -p ${DOLPHINSCHEDULER_LOGS} && mkdir -p /var/log/nginx/ && cat /dev/null >> ${LOGFILE}
+
 echo "tail begin"
 exec bash -c "tail -n 1 -f ${LOGFILE}"
 

--- a/dockerfile/startup.sh
+++ b/dockerfile/startup.sh
@@ -164,6 +164,7 @@ case "$1" in
         LOGFILE=${DOLPHINSCHEDULER_LOGS}/dolphinscheduler-worker.log
     ;;
     (api-server)
+        initZK
         initPostgreSQL
         initApiServer
         LOGFILE=${DOLPHINSCHEDULER_LOGS}/dolphinscheduler-api-server.log
@@ -187,6 +188,6 @@ case "$1" in
     ;;
 esac
 
-echo "tee begin"
-exec tee ${LOGFILE}
+echo "tail begin"
+exec bash -c "tail -n 1 -f ${LOGFILE}"
 


### PR DESCRIPTION
1. add tini
2. replace `tee` command by `tail` command in **startup.sh**
3. api-server need to support zookeeper