### PR TITLE
fix wrong sonar analysis coverage with checkout V2.

### DIFF
--- a/.github/workflows/ci_ut.yml
+++ b/.github/workflows/ci_ut.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-on: ["pull_request"]
+on: ["pull_request", "push"]
 env:
   DOCKER_DIR: ./docker
   LOG_DIR: /tmp/dolphinscheduler
@@ -52,7 +52,15 @@ jobs:
         run: |
           export MAVEN_OPTS='-Dmaven.repo.local=.m2/repository -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:-UseGCOverheadLimit -Xmx3g'
           mvn test -B -Dmaven.test.skip=false
+      - name: Upload coverage report to codecov
+        if: github.event_name == 'pull_request'
+        run: |
           CODECOV_TOKEN="09c2663f-b091-4258-8a47-c981827eb29a" bash <(curl -s https://codecov.io/bash)
+      - name: Git fetch unshallow
+        run: |
+          git fetch --unshallow
+          git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+          git fetch origin
       - name: Run SonarCloud Analysis
         run: >
           mvn verify --batch-mode


### PR DESCRIPTION
## What is the purpose of the pull request
with checkout V2, sonar analysis get warning like:
```
...
[WARNING] Missing blame information for the following files:
[WARNING]   * dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/ExecuteTaskResponseCommand.java
[WARNING]   * dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/CommandType.java
[WARNING]   * dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/DateUtils.java
[WARNING]   * dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/ExecuteTaskRequestCommand.java
[WARNING] This may lead to missing/broken features in SonarCloud
...
```

and then sonar analysis get the wrong coverage for PR

## Brief change log
1. add both push and pull request for ui_ct workflow.
2. upload coverage report just run on pull request event.
3. after test, run git command to convert a shallow repository to a complete one.
```
git fetch --unshallow
git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
git fetch origin
```

## Verify this pull request
test on my repo
https://github.com/Jave-Chen/incubator-dolphinscheduler/pull/9/checks?check_run_id=500815729

there isn't any blame warning.
