### PR TITLE
当手动重跑历史活着补数的时候对shell和sql脚本中的[YYYYmmddd...]变量赋值与传递的日期，而不是当前日期

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/Constants.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/Constants.java
@@ -1000,4 +1000,11 @@ public final class Constants {
      * dataSource sensitive param
      */
     public static final String DATASOURCE_PASSWORD_REGEX = "(?<=(\"password\":\")).*?(?=(\"))";
+
+    /**
+     * new
+     * schedule time
+     */
+    public static final String PARAMETER_SHECDULE_TIME = "schedule.time";
+
 }

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/ParameterUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/ParameterUtils.java
@@ -79,6 +79,68 @@ public class ParameterUtils {
   }
 
   /**
+   * new
+   * 新增方法替换调度时间
+   * convert parameters place holders
+   *
+   * @param parameterString parameter
+   * @param parameterMap parameter map
+   * @return convert parameters place holders
+   */
+  public static String convertParameterPlaceholders2(String parameterString, Map<String, String> parameterMap) {
+    if (StringUtils.isEmpty(parameterString)) {
+      return parameterString;
+    }
+    //Get current time, schedule execute time
+    String cronTimeStr = parameterMap.get(Constants.PARAMETER_SHECDULE_TIME);
+    Date cronTime = null;
+
+    if (StringUtils.isNotEmpty(cronTimeStr)) {
+      try {
+        cronTime = DateUtils.parseDate(cronTimeStr, new String[]{Constants.PARAMETER_FORMAT_TIME});
+
+      } catch (ParseException e) {
+        logger.error(String.format("parse %s exception", cronTimeStr), e);
+      }
+    } else {
+      cronTime = new Date();
+    }
+
+    // replace variable ${} form,refers to the replacement of system variables and custom variables
+    parameterString = PlaceholderUtils.replacePlaceholders(parameterString, parameterMap, true);
+
+    // replace time $[...] form, eg. $[yyyyMMdd]
+    if (cronTime != null) {
+      parameterString = TimePlaceholderUtils.replacePlaceholders(parameterString, cronTime, true);
+
+    }
+    return parameterString;
+  }
+
+  /**
+   * new
+   * $[yyyyMMdd] replace scheduler time
+   * @param text
+   * @param paramsMap
+   * @return
+   */
+  public static String replaceScheduleTime(String text, Date scheduleTime, Map<String, Property> paramsMap) {
+    if (paramsMap != null) {
+      //if getScheduleTime null ,is current date
+      if (null == scheduleTime) {
+        scheduleTime = new Date();
+      }
+      String dateTime = org.apache.dolphinscheduler.common.utils.DateUtils.format(scheduleTime, Constants.PARAMETER_FORMAT_TIME);
+      Property p = new Property();
+      p.setValue(dateTime);
+      p.setProp(Constants.PARAMETER_SHECDULE_TIME);
+      paramsMap.put(Constants.PARAMETER_SHECDULE_TIME, p);
+      text = ParameterUtils.convertParameterPlaceholders2(text, convert(paramsMap));
+    }
+    return text;
+  }
+
+  /**
    *  set in parameter
    * @param index index
    * @param stmt preparedstatement
@@ -176,5 +238,22 @@ public class ParameterUtils {
       return inputString.replace("%", "////%");
     }
     return inputString;
+  }
+
+
+  /**
+   * format convert
+   * @param paramsMap params map
+   * @return Map of converted
+   * see org.apache.dolphinscheduler.server.utils.ParamUtils.convert
+   */
+  public static Map<String,String> convert(Map<String,Property> paramsMap){
+    Map<String,String> map = new HashMap<>();
+    Iterator<Map.Entry<String, Property>> iter = paramsMap.entrySet().iterator();
+    while (iter.hasNext()){
+      Map.Entry<String, Property> en = iter.next();
+      map.put(en.getKey(),en.getValue().getValue());
+    }
+    return map;
   }
 }

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/shell/ShellTask.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/shell/ShellTask.java
@@ -21,6 +21,7 @@ import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.process.Property;
 import org.apache.dolphinscheduler.common.task.AbstractParameters;
 import org.apache.dolphinscheduler.common.task.shell.ShellParameters;
+import org.apache.dolphinscheduler.common.utils.DateUtils;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.common.utils.ParameterUtils;
 import org.apache.dolphinscheduler.common.utils.SpringApplicationContext;
@@ -141,10 +142,21 @@ public class ShellTask extends AbstractTask {
             shellParameters.getLocalParametersMap(),
             taskProps.getCmdTypeIfComplement(),
             taskProps.getScheduleTime());
-    if (paramsMap != null){
-      script = ParameterUtils.convertParameterPlaceholders(script, ParamUtils.convert(paramsMap));
-    }
+//
+//    if (paramsMap != null){
+//      script = ParameterUtils.convertParameterPlaceholders(script, ParamUtils.convert(paramsMap));
+//    }
 
+    //new
+    // replace shell $[YYYYmmddd...]
+    if (paramsMap != null){
+      String dateTime = DateUtils.format(taskProps.getScheduleTime(), Constants.PARAMETER_FORMAT_TIME);
+      Property p = new Property();
+      p.setValue(dateTime);
+      p.setProp(Constants.PARAMETER_SHECDULE_TIME);
+      paramsMap.put(Constants.PARAMETER_SHECDULE_TIME, p);
+      script = ParameterUtils.convertParameterPlaceholders2(script, ParamUtils.convert(paramsMap));
+    }
 
     shellParameters.setRawScript(script);
 

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/sql/SqlTask.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/sql/SqlTask.java
@@ -236,6 +236,9 @@ public class SqlTask extends AbstractTask {
             sqlParameters.setTitle(title);
         }
 
+        //new add,手动执行，手动补数，自动调度，历史重跑调度日期替换$[yyyy-MM-dd]
+        sql = ParameterUtils.replaceScheduleTime(sql, taskProps.getScheduleTime(), paramsMap);
+
         // special characters need to be escaped, ${} needs to be escaped
         String rgex = "['\"]*\\$\\{(.*?)\\}['\"]*";
         setSqlParamsMap(sql, rgex, sqlParamsMap, paramsMap);


### PR DESCRIPTION
## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds checkstyle plugin.)*

## Brief change log

*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.*
