### PR TITLE
Decouple DruidDataSource in ConnectionFactory and cache DataSource instance

### DIFF
--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/AlertDao.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/AlertDao.java
@@ -169,5 +169,11 @@ public class AlertDao extends AbstractBaseDao {
         return userAlertGroupMapper.listUserByAlertgroupId(alertgroupId);
     }
 
-
+    /**
+     * for test
+     * @return
+     */
+    public AlertMapper getAlertMapper() {
+        return alertMapper;
+    }
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/datasource/ConnectionFactory.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/datasource/ConnectionFactory.java
@@ -51,9 +51,9 @@ public class ConnectionFactory extends SpringConnectionFactory {
 
     private ConnectionFactory() {
         try {
+            dataSource = buildDataSource();
             sqlSessionFactory = getSqlSessionFactory();
             sqlSessionTemplate = getSqlSessionTemplate();
-            dataSource = buildDataSource();
         } catch (Exception e) {
             logger.error("Initializing ConnectionFactory error", e);
             throw new RuntimeException(e);

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/datasource/ConnectionFactory.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/datasource/ConnectionFactory.java
@@ -119,10 +119,9 @@ public class ConnectionFactory extends SpringConnectionFactory {
      * @throws Exception sqlSessionFactory exception
      */
     private SqlSessionFactory getSqlSessionFactory() throws Exception {
-        DataSource dataSource = getDataSource();
         TransactionFactory transactionFactory = new JdbcTransactionFactory();
 
-        Environment environment = new Environment("development", transactionFactory, dataSource);
+        Environment environment = new Environment("development", transactionFactory, getDataSource());
 
         MybatisConfiguration configuration = new MybatisConfiguration();
         configuration.setEnvironment(environment);
@@ -132,7 +131,7 @@ public class ConnectionFactory extends SpringConnectionFactory {
 
         MybatisSqlSessionFactoryBean sqlSessionFactoryBean = new MybatisSqlSessionFactoryBean();
         sqlSessionFactoryBean.setConfiguration(configuration);
-        sqlSessionFactoryBean.setDataSource(dataSource);
+        sqlSessionFactoryBean.setDataSource(getDataSource());
 
         sqlSessionFactoryBean.setTypeEnumsPackage("org.apache.dolphinscheduler.*.enums");
         sqlSessionFactory = sqlSessionFactoryBean.getObject();

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/datasource/ConnectionFactory.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/datasource/ConnectionFactory.java
@@ -53,6 +53,7 @@ public class ConnectionFactory extends SpringConnectionFactory {
         try {
             sqlSessionFactory = getSqlSessionFactory();
             sqlSessionTemplate = getSqlSessionTemplate();
+            dataSource = buildDataSource();
         } catch (Exception e) {
             logger.error("Initializing ConnectionFactory error", e);
             throw new RuntimeException(e);
@@ -69,12 +70,18 @@ public class ConnectionFactory extends SpringConnectionFactory {
      */
     private SqlSessionTemplate sqlSessionTemplate;
 
+    private DataSource dataSource;
+
+    public DataSource getDataSource() {
+        return dataSource;
+    }
+
     /**
      * get the data source
      *
      * @return druid dataSource
      */
-    public DruidDataSource getDataSource() {
+    private DataSource buildDataSource() {
 
         DruidDataSource druidDataSource = new DruidDataSource();
 

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/upgrade/UpgradeDao.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/upgrade/UpgradeDao.java
@@ -54,8 +54,7 @@ public abstract class UpgradeDao extends AbstractBaseDao {
      * @return DruidDataSource
      */
     public static DataSource getDataSource(){
-        DataSource dataSource = ConnectionFactory.getInstance().getDataSource();
-        return dataSource;
+        return ConnectionFactory.getInstance().getDataSource();
     }
 
     /**

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/upgrade/UpgradeDao.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/upgrade/UpgradeDao.java
@@ -27,6 +27,7 @@ import org.apache.dolphinscheduler.dao.datasource.ConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.sql.DataSource;
 import java.io.*;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -40,7 +41,7 @@ public abstract class UpgradeDao extends AbstractBaseDao {
     private static final String T_VERSION_NAME = "t_escheduler_version";
     private static final String T_NEW_VERSION_NAME = "t_ds_version";
     private static final String rootDir = System.getProperty("user.dir");
-    protected static final DruidDataSource dataSource = getDataSource();
+    protected static final DataSource dataSource = getDataSource();
     private static final DbType dbType = getCurrentDbType();
 
     @Override
@@ -52,12 +53,8 @@ public abstract class UpgradeDao extends AbstractBaseDao {
      * get datasource
      * @return DruidDataSource
      */
-    public static DruidDataSource getDataSource(){
-        DruidDataSource dataSource = ConnectionFactory.getInstance().getDataSource();
-        dataSource.setInitialSize(2);
-        dataSource.setMinIdle(2);
-        dataSource.setMaxActive(2);
-
+    public static DataSource getDataSource(){
+        DataSource dataSource = ConnectionFactory.getInstance().getDataSource();
         return dataSource;
     }
 

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/AlertDaoTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/AlertDaoTest.java
@@ -16,10 +16,14 @@
  */
 package org.apache.dolphinscheduler.dao;
 
+import org.apache.dolphinscheduler.dao.entity.Alert;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class AlertDaoTest {
     private static final Logger logger = LoggerFactory.getLogger(AlertDaoTest.class);
@@ -30,5 +34,13 @@ public class AlertDaoTest {
         AlertDao alertDao = DaoFactory.getDaoInstance(AlertDao.class);
         Assert.assertNotNull(alertDao);
         logger.info("testGetAlertDao end");
+    }
+
+    @Test
+    public void testQuery(){
+        AlertDao alertDao = DaoFactory.getDaoInstance(AlertDao.class);
+        List<Alert> alerts = alertDao.listWaitExecutionAlert();
+        Assert.assertNotNull(alerts);
+        Assert.assertNotEquals(0, alerts.size());
     }
 }

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/AlertDaoTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/AlertDaoTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dolphinscheduler.dao;
 
+import org.apache.dolphinscheduler.common.enums.AlertStatus;
 import org.apache.dolphinscheduler.common.enums.AlertType;
 import org.apache.dolphinscheduler.common.enums.ShowType;
 import org.apache.dolphinscheduler.dao.entity.Alert;
@@ -40,11 +41,19 @@ public class AlertDaoTest {
                 "\"get the alarm exception.！，interface error，exception information：timed out\", \"request address：http://blog.csdn.net/dreamInTheWorld/article/details/78539286\"]");
         alert.setAlertType(AlertType.EMAIL);
         alert.setAlertGroupId(1);
+        alert.setAlertStatus(AlertStatus.WAIT_EXECUTION);
         alertDao.addAlert(alert);
+
+
         List<Alert> alerts = alertDao.listWaitExecutionAlert();
         Assert.assertNotNull(alerts);
         Assert.assertNotEquals(0, alerts.size());
         int id = alerts.get(0).getId();
+        AlertStatus alertStatus = alerts.get(0).getAlertStatus();
+        alertDao.updateAlert(AlertStatus.EXECUTION_SUCCESS, "", id);
+
+        alerts = alertDao.listWaitExecutionAlert();
+        Assert.assertNotEquals(alertStatus, alerts.get(0).getAlertStatus());
         alertDao.getAlertMapper().deleteById(id);
     }
 }

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/AlertDaoTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/AlertDaoTest.java
@@ -53,7 +53,7 @@ public class AlertDaoTest {
         alertDao.updateAlert(AlertStatus.EXECUTION_SUCCESS, "", id);
 
         alerts = alertDao.listWaitExecutionAlert();
-        Assert.assertNotEquals(alertStatus, alerts.get(0).getAlertStatus());
+        Assert.assertEquals(0, alerts.size());
         alertDao.getAlertMapper().deleteById(id);
     }
 }

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/AlertDaoTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/AlertDaoTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.dolphinscheduler.dao;
 
+import org.apache.dolphinscheduler.common.enums.AlertType;
+import org.apache.dolphinscheduler.common.enums.ShowType;
 import org.apache.dolphinscheduler.dao.entity.Alert;
 import org.junit.Assert;
 import org.junit.Test;
@@ -29,18 +31,19 @@ public class AlertDaoTest {
     private static final Logger logger = LoggerFactory.getLogger(AlertDaoTest.class);
 
     @Test
-    public void testGetAlertDao() {
-        logger.info("testGetAlertDao start");
+    public void testAlertDao(){
         AlertDao alertDao = DaoFactory.getDaoInstance(AlertDao.class);
-        Assert.assertNotNull(alertDao);
-        logger.info("testGetAlertDao end");
-    }
-
-    @Test
-    public void testQuery(){
-        AlertDao alertDao = DaoFactory.getDaoInstance(AlertDao.class);
+        Alert alert = new Alert();
+        alert.setTitle("Mysql Exception");
+        alert.setShowType(ShowType.TEXT);
+        alert.setContent("[\"alarm time：2018-02-05\", \"service name：MYSQL_ALTER\", \"alarm name：MYSQL_ALTER_DUMP\", " +
+                "\"get the alarm exception.！，interface error，exception information：timed out\", \"request address：http://blog.csdn.net/dreamInTheWorld/article/details/78539286\"]");
+        alert.setAlertType(AlertType.EMAIL);
+        alert.setAlertGroupId(1);
         List<Alert> alerts = alertDao.listWaitExecutionAlert();
         Assert.assertNotNull(alerts);
         Assert.assertNotEquals(0, alerts.size());
+        int id = alerts.get(0).getId();
+        alertDao.getAlertMapper().deleteById(id);
     }
 }

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/AlertDaoTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/AlertDaoTest.java
@@ -29,8 +29,6 @@ import java.util.Arrays;
 import java.util.List;
 
 public class AlertDaoTest {
-    private static final Logger logger = LoggerFactory.getLogger(AlertDaoTest.class);
-
     @Test
     public void testAlertDao(){
         AlertDao alertDao = DaoFactory.getDaoInstance(AlertDao.class);

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/AlertDaoTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/AlertDaoTest.java
@@ -40,6 +40,7 @@ public class AlertDaoTest {
                 "\"get the alarm exception.！，interface error，exception information：timed out\", \"request address：http://blog.csdn.net/dreamInTheWorld/article/details/78539286\"]");
         alert.setAlertType(AlertType.EMAIL);
         alert.setAlertGroupId(1);
+        alertDao.addAlert(alert);
         List<Alert> alerts = alertDao.listWaitExecutionAlert();
         Assert.assertNotNull(alerts);
         Assert.assertNotEquals(0, alerts.size());

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/ConnectionFactoryTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/ConnectionFactoryTest.java
@@ -31,7 +31,7 @@ public class ConnectionFactoryTest {
      */
     @Test
     public void testConnection()throws Exception{
-        Connection connection = ConnectionFactory.getInstance().getDataSource().getPooledConnection().getConnection();
+        Connection connection = ConnectionFactory.getInstance().getDataSource().getConnection();
         Assert.assertTrue(connection != null);
     }
 }


### PR DESCRIPTION

## What is the purpose of the pull request

Return java.sql.DataSource to decouple DruidSource. And cache DataSource instance.

## Brief change log

*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.*
