### PR TITLE
add Retryer to retry Task Execute ack gracefully

### DIFF
--- a/dolphinscheduler-server/pom.xml
+++ b/dolphinscheduler-server/pom.xml
@@ -112,7 +112,25 @@
 			<groupId>org.apache.dolphinscheduler</groupId>
 			<artifactId>dolphinscheduler-alert</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.github.rholder</groupId>
+			<artifactId>guava-retrying</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.code.findbugs</groupId>
+					<artifactId>jsr305</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		
 		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-module-junit4</artifactId>

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskExecuteProcessor.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskExecuteProcessor.java
@@ -130,7 +130,7 @@ public class TaskExecuteProcessor implements NettyRequestProcessor {
 
     private static Callable<Boolean> doAck(final TaskCallbackService taskExecuteProcessor, final int taskInstanceId, final Command ackCommand) {
         return () -> {
-            taskExecuteProcessor.sendAck(taskInstanceId,ackCommand);
+            taskExecuteProcessor.sendAck(taskInstanceId, ackCommand);
             return true;
         };
     }

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@
         <servlet-api.version>2.5</servlet-api.version>
         <swagger.version>1.9.3</swagger.version>
         <springfox.version>2.9.2</springfox.version>
+        <guava-retrying.version>2.0.0</guava-retrying.version>
     </properties>
 
     <dependencyManagement>
@@ -543,6 +544,11 @@
                 <groupId>com.github.xiaoymin</groupId>
                 <artifactId>swagger-bootstrap-ui</artifactId>
                 <version>${swagger.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.rholder</groupId>
+                <artifactId>guava-retrying</artifactId>
+                <version>${guava-retrying.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -209,3 +209,4 @@ xml-apis-1.4.01.jar
 xmlenc-0.52.jar
 xz-1.0.jar
 zookeeper-3.4.14.jar
+guava-retrying-2.0.0.jar


### PR DESCRIPTION
## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

## What is the purpose of the pull request

Now, dolphin already refactor worker ,and netty is being used.
It can be predicted that async method will be more and more used ,and function retryer is necessary .
If we simply call function twice or more , it's ugly and beyonds understanding

So I suggest we introduce a retryer class ,for example https://github.com/rholder/guava-retrying

## Brief change log

  - Add guava-retrying to root pom.xml and dolphinscheduler-server pom.xml
 - Add retry logic to TaskExecuteProcessor

