### PR TITLE
[BUF FIX]fix: the master would be blocked when worker group not exists

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/config/MasterConfig.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/config/MasterConfig.java
@@ -37,6 +37,9 @@ public class MasterConfig {
     @Value("${master.task.commit.retryTimes:5}")
     private int masterTaskCommitRetryTimes;
 
+    @Value("${master.dispatch.task.num :3}")
+    private int masterDispatchTaskNumber;
+
     @Value("${master.task.commit.interval:1000}")
     private int masterTaskCommitInterval;
 
@@ -125,5 +128,13 @@ public class MasterConfig {
 
     public void setMasterReservedMemory(double masterReservedMemory) {
         this.masterReservedMemory = masterReservedMemory;
+    }
+
+    public int getMasterDispatchTaskNumber() {
+        return masterDispatchTaskNumber;
+    }
+
+    public void setMasterDispatchTaskNumber(int masterDispatchTaskNumber) {
+        this.masterDispatchTaskNumber = masterDispatchTaskNumber;
     }
 }

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/consumer/TaskPriorityQueueConsumer.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/consumer/TaskPriorityQueueConsumer.java
@@ -101,13 +101,11 @@ public class TaskPriorityQueueConsumer extends Thread{
 
     @Override
     public void run() {
+        List<String> failedDispatchTasks = new ArrayList<>();
         while (Stopper.isRunning()){
             try {
-
-                List<String> failedDispatchTasks = new ArrayList<>();
-
                 int fetchTaskNum = masterConfig.getMasterDispatchTaskNumber();
-
+                failedDispatchTasks.clear();
                 for(int i = 0; i < fetchTaskNum; i++){
                     // if not task , blocking here
                     String taskPriorityInfo = taskPriorityQueue.take();
@@ -120,7 +118,6 @@ public class TaskPriorityQueueConsumer extends Thread{
                 for(String taskPriorityInfo: failedDispatchTasks){
                     taskPriorityQueue.put(taskPriorityInfo);
                 }
-
             }catch (Exception e){
                 logger.error("dispatcher task error",e);
             }
@@ -135,10 +132,11 @@ public class TaskPriorityQueueConsumer extends Thread{
      * @return result
      */
     private boolean dispatch(int taskInstanceId){
-        TaskExecutionContext context = getTaskExecutionContext(taskInstanceId);
-        ExecutionContext executionContext = new ExecutionContext(context.toCommand(), ExecutorType.WORKER, context.getWorkerGroup());
         boolean result = false;
         try {
+            TaskExecutionContext context = getTaskExecutionContext(taskInstanceId);
+            ExecutionContext executionContext = new ExecutionContext(context.toCommand(), ExecutorType.WORKER, context.getWorkerGroup());
+
             if (taskInstanceIsFinalState(taskInstanceId)){
                 // when task finish, ignore this task, there is no need to dispatch anymore
                 return true;

--- a/dolphinscheduler-server/src/main/resources/master.properties
+++ b/dolphinscheduler-server/src/main/resources/master.properties
@@ -21,6 +21,10 @@
 # master execute task number in parallel
 #master.exec.task.num=20
 
+
+# master dispatch task number
+#master.dispatch.task.num = 3
+
 # master heartbeat interval
 #master.heartbeat.interval=10
 

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/consumer/TaskPriorityQueueConsumerTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/consumer/TaskPriorityQueueConsumerTest.java
@@ -22,6 +22,7 @@ import org.apache.dolphinscheduler.common.enums.DbType;
 import org.apache.dolphinscheduler.common.enums.ExecutionStatus;
 import org.apache.dolphinscheduler.common.enums.Priority;
 import org.apache.dolphinscheduler.dao.entity.*;
+import org.apache.dolphinscheduler.server.master.config.MasterConfig;
 import org.apache.dolphinscheduler.server.master.dispatch.ExecutorDispatcher;
 import org.apache.dolphinscheduler.server.master.dispatch.executor.NettyExecutorManager;
 import org.apache.dolphinscheduler.server.registry.DependencyConfig;
@@ -48,7 +49,7 @@ import java.util.Date;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes={DependencyConfig.class, SpringApplicationContext.class, SpringZKServer.class,
         NettyExecutorManager.class, ExecutorDispatcher.class, ZookeeperRegistryCenter.class, TaskPriorityQueueConsumer.class,
-        ZookeeperNodeManager.class, ZookeeperCachedOperator.class, ZookeeperConfig.class})
+        ZookeeperNodeManager.class, ZookeeperCachedOperator.class, ZookeeperConfig.class, MasterConfig.class})
 public class TaskPriorityQueueConsumerTest {
 
 

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/runner/MasterTaskExecThreadTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/runner/MasterTaskExecThreadTest.java
@@ -42,7 +42,7 @@ import java.util.Set;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes={DependencyConfig.class, SpringApplicationContext.class, SpringZKServer.class,
         NettyExecutorManager.class, ExecutorDispatcher.class, ZookeeperRegistryCenter.class, TaskPriorityQueueConsumer.class,
-        ZookeeperNodeManager.class, ZookeeperCachedOperator.class, ZookeeperConfig.class, MasterConfig.class})
+        ZookeeperNodeManager.class, ZookeeperCachedOperator.class, ZookeeperConfig.class})
 public class MasterTaskExecThreadTest {
 
     @Test

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/registry/DependencyConfig.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/registry/DependencyConfig.java
@@ -20,6 +20,7 @@ package org.apache.dolphinscheduler.server.registry;
 import org.apache.dolphinscheduler.dao.AlertDao;
 import org.apache.dolphinscheduler.dao.mapper.*;
 import org.apache.dolphinscheduler.server.master.cache.impl.TaskInstanceCacheManagerImpl;
+import org.apache.dolphinscheduler.server.master.config.MasterConfig;
 import org.apache.dolphinscheduler.server.master.dispatch.ExecutorDispatcher;
 import org.apache.dolphinscheduler.server.master.dispatch.host.HostManager;
 import org.apache.dolphinscheduler.server.master.dispatch.host.RandomHostManager;
@@ -63,6 +64,10 @@ public class DependencyConfig {
         return Mockito.mock(ProcessService.class);
     }
 
+    @Bean
+    public MasterConfig masterConfig(){
+        return Mockito.mock(MasterConfig.class);
+    }
     @Bean
     public UserMapper userMapper(){
         return Mockito.mock(UserMapper.class);


### PR DESCRIPTION
## What is the purpose of the pull request
fix bug(#2762): master would be blocked when worker group not exists


## Brief change log
1. master would not dispatch one task in loop.
2. master would put the failure tasks in the queue again.

