### PR TITLE
(Abandoned) Please go to #2970 PR.

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/DataSourceService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/DataSourceService.java
@@ -506,6 +506,7 @@ public class DataSourceService extends BaseService{
         }
 
         Map<String, Object> parameterMap = new LinkedHashMap<String, Object>(6);
+        parameterMap.put(TYPE, connectType);
         parameterMap.put(Constants.ADDRESS, address);
         parameterMap.put(Constants.DATABASE, database);
         parameterMap.put(Constants.JDBC_URL, jdbcUrl);

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/DataSourceServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/DataSourceServiceTest.java
@@ -19,6 +19,7 @@ package org.apache.dolphinscheduler.api.service;
 import org.apache.dolphinscheduler.api.ApiApplicationServer;
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.common.enums.DbConnectType;
 import org.apache.dolphinscheduler.common.enums.DbType;
 import org.apache.dolphinscheduler.common.enums.UserType;
 import org.apache.dolphinscheduler.dao.entity.User;
@@ -49,5 +50,13 @@ public class DataSourceServiceTest {
         loginUser.setUserType(UserType.GENERAL_USER);
         Map<String, Object> map = dataSourceService.queryDataSourceList(loginUser, DbType.MYSQL.ordinal());
         Assert.assertEquals(Status.SUCCESS, map.get(Constants.STATUS));
+    }
+
+    @Test
+    public void buildParameter(){
+        String param = dataSourceService.buildParameter("","", DbType.ORACLE, "192.168.9.1","1521","im"
+                ,"","test","test", DbConnectType.ORACLE_SERVICE_NAME,"");
+        String expected = "{\"type\":\"ORACLE_SERVICE_NAME\",\"address\":\"jdbc:oracle:thin:@//192.168.9.1:1521\",\"database\":\"im\",\"jdbcUrl\":\"jdbc:oracle:thin:@//192.168.9.1:1521/im\",\"user\":\"test\",\"password\":\"test\"}";
+        Assert.assertEquals(expected, param);
     }
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/datasource/BaseDataSource.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/datasource/BaseDataSource.java
@@ -97,7 +97,7 @@ public abstract class BaseDataSource {
    * append database
    * @param jdbcUrl jdbc url
    */
-  private void appendDatabase(StringBuilder jdbcUrl) {
+  protected void appendDatabase(StringBuilder jdbcUrl) {
     if (dbTypeSelector() == DbType.SQLSERVER) {
       jdbcUrl.append(";databaseName=").append(getDatabase());
     } else {

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/datasource/OracleDataSource.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/datasource/OracleDataSource.java
@@ -19,8 +19,6 @@ package org.apache.dolphinscheduler.dao.datasource;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.DbConnectType;
 import org.apache.dolphinscheduler.common.enums.DbType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * data source of Oracle
@@ -46,16 +44,16 @@ public class OracleDataSource extends BaseDataSource {
     }
 
     /**
-     * gets the JDBC url for the data source connection
-     * @return jdbc url
+     * append service name or SID
      */
     @Override
-    public String getJdbcUrl() {
-        String jdbcUrl = getAddress();
-        if (jdbcUrl.lastIndexOf("/") != (jdbcUrl.length() - 1)) {
-            jdbcUrl += "/";
+    protected void appendDatabase(StringBuilder jdbcUrl) {
+        if (getType() == DbConnectType.ORACLE_SID) {
+            jdbcUrl.append(":");
+        } else {
+            jdbcUrl.append("/");
         }
-        return jdbcUrl;
+        jdbcUrl.append(getDatabase());
     }
 
     /**

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/datasource/OracleDataSourceTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/datasource/OracleDataSourceTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dolphinscheduler.dao.datasource;
+
+import org.apache.dolphinscheduler.common.enums.DbConnectType;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class OracleDataSourceTest {
+
+    @Test
+    public void testGetOracleJdbcUrl() {
+        OracleDataSource oracleDataSource = new OracleDataSource();
+        oracleDataSource.setType(DbConnectType.ORACLE_SERVICE_NAME);
+        oracleDataSource.setAddress("jdbc:oracle:thin:@//127.0.0.1:1521");
+        oracleDataSource.setDatabase("test");
+        oracleDataSource.setPassword("123456");
+        oracleDataSource.setUser("test");
+        Assert.assertEquals("jdbc:oracle:thin:@//127.0.0.1:1521/test", oracleDataSource.getJdbcUrl());
+        //set fake principal
+        oracleDataSource.setPrincipal("fake principal");
+        Assert.assertEquals("jdbc:oracle:thin:@//127.0.0.1:1521/test", oracleDataSource.getJdbcUrl());
+        //set fake other
+        oracleDataSource.setOther("charset=UTF-8");
+        Assert.assertEquals("jdbc:oracle:thin:@//127.0.0.1:1521/test?charset=UTF-8", oracleDataSource.getJdbcUrl());
+
+        OracleDataSource oracleDataSource2 = new OracleDataSource();
+        oracleDataSource2.setAddress("jdbc:oracle:thin:@127.0.0.1:1521");
+        oracleDataSource2.setDatabase("orcl");
+        oracleDataSource2.setPassword("123456");
+        oracleDataSource2.setUser("test");
+        oracleDataSource2.setType(DbConnectType.ORACLE_SID);
+        Assert.assertEquals("jdbc:oracle:thin:@127.0.0.1:1521:orcl", oracleDataSource2.getJdbcUrl());
+        //set fake principal
+        oracleDataSource2.setPrincipal("fake principal");
+        Assert.assertEquals("jdbc:oracle:thin:@127.0.0.1:1521:orcl", oracleDataSource2.getJdbcUrl());
+        //set fake other
+        oracleDataSource2.setOther("charset=UTF-8");
+        Assert.assertEquals("jdbc:oracle:thin:@127.0.0.1:1521:orcl?charset=UTF-8", oracleDataSource2.getJdbcUrl());
+    }
+
+    @Test
+    public void testAppendDatabase() {
+        OracleDataSource oracleDataSource = new OracleDataSource();
+        oracleDataSource.setAddress("jdbc:oracle:thin:@//127.0.0.1:1521");
+        oracleDataSource.setDatabase("test");
+        oracleDataSource.setType(DbConnectType.ORACLE_SERVICE_NAME);
+        StringBuilder jdbcUrl = new StringBuilder(oracleDataSource.getAddress());
+        oracleDataSource.appendDatabase(jdbcUrl);
+        Assert.assertEquals("jdbc:oracle:thin:@//127.0.0.1:1521/test", jdbcUrl.toString());
+
+        OracleDataSource oracleDataSource2 = new OracleDataSource();
+        oracleDataSource2.setAddress("jdbc:oracle:thin:@127.0.0.1:1521");
+        oracleDataSource2.setDatabase("orcl");
+        oracleDataSource2.setType(DbConnectType.ORACLE_SID);
+        StringBuilder jdbcUrl2 = new StringBuilder(oracleDataSource2.getAddress());
+        oracleDataSource2.appendDatabase(jdbcUrl2);
+        Assert.assertEquals("jdbc:oracle:thin:@127.0.0.1:1521:orcl", jdbcUrl2.toString());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -847,6 +847,7 @@
                         <include>**/dao/mapper/UserMapperTest.java</include>
                         <include>**/dao/utils/DagHelperTest.java</include>
                         <include>**/dao/AlertDaoTest.java</include>
+                        <include>**/dao/datasource/OracleDataSourceTest.java</include>
                         <include>**/plugin/model/AlertDataTest.java</include>
                         <include>**/plugin/model/AlertInfoTest.java</include>
                         <include>**/plugin/utils/PropertyUtilsTest.java</include>


### PR DESCRIPTION
## What is the purpose of the pull request

This pull request modify the JDBC format of the Oracle database connection.
Number:#2791.
pull/2792 ，pull/2818has been abandoned for other reasons.

The Oracle JDBC link I verified currently supports the following three methods:
jdbc:oracle:thin:@host:port:SID
jdbc:oracle:thin:@//host:port/service_name
jdbc:oracle:thin:@host:port/service_name
The above three methods are verified in the unit test.

## Brief change log

DataSourceService.java:
Add Oracle link type parameter in buildParameter().
BaseDataSource.java:
Modify appendDatabase () method as a protected modifier to facilitate OracleDataSource to rewrite this method.
OracleDataSource.java:
Override appendDatabase () method.
OracleDataSourceTest.java:
Unit test the newly modified code.
DataSourceServiceTest.java:
Add buildParameter () unit test.
pom.xml:
added a line in the maven-surefire-plugin section of the pom file to ensure that my OracleDataSourceTest.java file can be executed, thus ensuring my code coverage.


## Verify this pull request

This change added tests and can be verified as follows:

Add the Oracle data source in the data source center, including using the service name or SID.
Perform the task of executing the Oracle data source on the SQL type node and pass the verification.
##Addition

If anything is wrong, you are welcome to participate in the discussion. Thanks.
