### PR TITLE
[Feature-2127][sql-schema] Fix the mysql version limited error (#2127)

### DIFF
--- a/escheduler-dao/src/main/java/cn/escheduler/dao/mapper/ProjectMapperProvider.java
+++ b/escheduler-dao/src/main/java/cn/escheduler/dao/mapper/ProjectMapperProvider.java
@@ -42,6 +42,8 @@ public class ProjectMapperProvider {
                 VALUES("`user_id`", "#{project.userId}");
                 VALUES("`name`", "#{project.name}");
                 VALUES("`desc`", "#{project.desc}");
+                VALUES("`create_time`", "#{project.createTime}");
+                VALUES("`update_time`", "#{project.updateTime}");
             }
         }.toString();
     }

--- a/sql/create/release-1.0.0_schema/mysql/escheduler_ddl.sql
+++ b/sql/create/release-1.0.0_schema/mysql/escheduler_ddl.sql
@@ -176,8 +176,8 @@ CREATE TABLE `t_escheduler_project` (
   `desc` varchar(200) DEFAULT NULL COMMENT '项目描述',
   `user_id` int(11) DEFAULT NULL COMMENT '所属用户',
   `flag` tinyint(4) DEFAULT '1' COMMENT '是否可用  1 可用,0 不可用',
-  `create_time` datetime DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
-  `update_time` datetime DEFAULT CURRENT_TIMESTAMP COMMENT '修改时间',
+  `create_time` datetime DEFAULT NULL COMMENT '创建时间',
+  `update_time` datetime DEFAULT NULL COMMENT '修改时间',
   PRIMARY KEY (`id`),
   KEY `user_id_index` (`user_id`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/sql/upgrade/1.0.2_schema/mysql/escheduler_ddl.sql
+++ b/sql/upgrade/1.0.2_schema/mysql/escheduler_ddl.sql
@@ -80,9 +80,9 @@ CREATE PROCEDURE ac_escheduler_T_t_escheduler_error_command()
            `failure_strategy` tinyint(4) NULL DEFAULT 0 COMMENT '失败策略：0结束，1继续',
            `warning_type` tinyint(4) NULL DEFAULT 0 COMMENT '告警类型',
            `warning_group_id` int(11) NULL DEFAULT NULL COMMENT '告警组',
-           `schedule_time` datetime(0) NULL DEFAULT NULL COMMENT '预期运行时间',
-           `start_time` datetime(0) NULL DEFAULT NULL COMMENT '开始时间',
-           `update_time` datetime(0) NULL DEFAULT NULL COMMENT '更新时间',
+           `schedule_time` datetime NULL DEFAULT NULL COMMENT '预期运行时间',
+           `start_time` datetime NULL DEFAULT NULL COMMENT '开始时间',
+           `update_time` datetime NULL DEFAULT NULL COMMENT '更新时间',
            `dependence` text CHARACTER SET utf8 COLLATE utf8_general_ci NULL COMMENT '依赖字段',
            `process_instance_priority` int(11) NULL DEFAULT NULL COMMENT '流程实例优先级：0 Highest,1 High,2 Medium,3 Low,4 Lowest',
            `worker_group_id` int(11) NULL DEFAULT -1 COMMENT '任务指定运行的worker分组',
@@ -108,8 +108,8 @@ CREATE PROCEDURE ac_escheduler_T_t_escheduler_worker_group()
            `id` bigint(11) NOT NULL AUTO_INCREMENT COMMENT 'id',
            `name` varchar(256)  NULL DEFAULT NULL COMMENT '组名称',
            `ip_list` varchar(256)  NULL DEFAULT NULL COMMENT 'worker地址列表',
-           `create_time` datetime(0) NULL DEFAULT NULL COMMENT '创建时间',
-           `update_time` datetime(0) NULL DEFAULT NULL COMMENT '更新时间',
+           `create_time` datetime NULL DEFAULT NULL COMMENT '创建时间',
+           `update_time` datetime NULL DEFAULT NULL COMMENT '更新时间',
            PRIMARY KEY (`id`) USING BTREE
        ) ENGINE = InnoDB AUTO_INCREMENT=1 CHARACTER SET = utf8 COLLATE = utf8_general_ci ROW_FORMAT = Dynamic;
 


### PR DESCRIPTION
## What is the purpose of the pull request

*Fix the mysql version and datetime sql syntax limited error for 5.5x - 5.64.*

## Brief change log

  - *Remove the CURRENT_TIMESTAMP in sql file.*
  - *Change the sql datetime(0) syntax to common syntax datetime, because mysql5.5x does not support the datetime(0) syntax, and datetime syntax is be in common use in mysql5.x and mysql8.x.*
  - *Add the setter for create_time and update_time in ProjectMapperProvider.java*

## Verify this pull request

This pull request is code cleanup without any test coverage.