### PR TITLE
[Feature-2127][sql-schema] Fix the mysql version limited error (#2127)

### DIFF
--- a/sql/create/release-1.0.0_schema/mysql/dolphinscheduler_ddl.sql
+++ b/sql/create/release-1.0.0_schema/mysql/dolphinscheduler_ddl.sql
@@ -193,8 +193,8 @@ CREATE TABLE `t_escheduler_project` (
   `desc` varchar(200) DEFAULT NULL COMMENT 'project description',
   `user_id` int(11) DEFAULT NULL COMMENT 'creator id',
   `flag` tinyint(4) DEFAULT '1' COMMENT '0 not available, 1 available',
-  `create_time` datetime DEFAULT CURRENT_TIMESTAMP COMMENT 'create time',
-  `update_time` datetime DEFAULT CURRENT_TIMESTAMP COMMENT 'update time',
+  `create_time` datetime DEFAULT NULL COMMENT 'create time',
+  `update_time` datetime DEFAULT NULL COMMENT 'update time',
   PRIMARY KEY (`id`),
   KEY `user_id_index` (`user_id`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/sql/dolphinscheduler_mysql.sql
+++ b/sql/dolphinscheduler_mysql.sql
@@ -479,8 +479,8 @@ CREATE TABLE `t_ds_project` (
   `description` varchar(200) DEFAULT NULL,
   `user_id` int(11) DEFAULT NULL COMMENT 'creator id',
   `flag` tinyint(4) DEFAULT '1' COMMENT '0 not available, 1 available',
-  `create_time` datetime DEFAULT CURRENT_TIMESTAMP COMMENT 'create time',
-  `update_time` datetime DEFAULT CURRENT_TIMESTAMP COMMENT 'update time',
+  `create_time` datetime DEFAULT NULL COMMENT 'create time',
+  `update_time` datetime DEFAULT NULL COMMENT 'update time',
   PRIMARY KEY (`id`),
   KEY `user_id_index` (`user_id`) USING BTREE
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;

--- a/sql/upgrade/1.0.2_schema/mysql/dolphinscheduler_ddl.sql
+++ b/sql/upgrade/1.0.2_schema/mysql/dolphinscheduler_ddl.sql
@@ -97,9 +97,9 @@ CREATE PROCEDURE ac_escheduler_T_t_escheduler_error_command()
            `failure_strategy` tinyint(4) NULL DEFAULT 0 COMMENT 'failure strategy',
            `warning_type` tinyint(4) NULL DEFAULT 0 COMMENT 'warning type',
            `warning_group_id` int(11) NULL DEFAULT NULL COMMENT 'warning group id',
-           `schedule_time` datetime(0) NULL DEFAULT NULL COMMENT 'scheduler time',
-           `start_time` datetime(0) NULL DEFAULT NULL COMMENT 'start time',
-           `update_time` datetime(0) NULL DEFAULT NULL COMMENT 'update time',
+           `schedule_time` datetime NULL DEFAULT NULL COMMENT 'scheduler time',
+           `start_time` datetime NULL DEFAULT NULL COMMENT 'start time',
+           `update_time` datetime NULL DEFAULT NULL COMMENT 'update time',
            `dependence` text CHARACTER SET utf8 COLLATE utf8_general_ci NULL COMMENT 'dependence',
            `process_instance_priority` int(11) NULL DEFAULT NULL COMMENT 'process instance priority, 0 Highest,1 High,2 Medium,3 Low,4 Lowest',
            `worker_group_id` int(11) NULL DEFAULT -1 COMMENT 'worker group id',
@@ -125,8 +125,8 @@ CREATE PROCEDURE ac_escheduler_T_t_escheduler_worker_group()
            `id` bigint(11) NOT NULL AUTO_INCREMENT COMMENT 'id',
            `name` varchar(256)  NULL DEFAULT NULL COMMENT 'worker group name',
            `ip_list` varchar(256)  NULL DEFAULT NULL COMMENT 'worker ip list. split by [,] ',
-           `create_time` datetime(0) NULL DEFAULT NULL COMMENT 'create time',
-           `update_time` datetime(0) NULL DEFAULT NULL COMMENT 'update time',
+           `create_time` datetime NULL DEFAULT NULL COMMENT 'create time',
+           `update_time` datetime NULL DEFAULT NULL COMMENT 'update time',
            PRIMARY KEY (`id`) USING BTREE
        ) ENGINE = InnoDB AUTO_INCREMENT=1 CHARACTER SET = utf8 COLLATE = utf8_general_ci ROW_FORMAT = Dynamic;
 


### PR DESCRIPTION
## What is the purpose of the pull request

*Fix the mysql version and datetime sql syntax limited error for 5.5x - 5.64.*

## Brief change log

  - *Remove the CURRENT_TIMESTAMP in sql file.*
  - *Change the sql datetime(0) syntax to common syntax datetime, because mysql5.5x does not support the datetime(0) syntax, and datetime syntax is be in common use in mysql5.x and mysql8.x.*
  - *There is no need to set datetime in java code, because the default time was set up before.*

## Verify this pull request

This pull request is code cleanup without any test coverage.