### PR TITLE
[Feature-2925][server] Init TaskLogger in TaskExecuteProcessor (#2925)

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/FileUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/FileUtils.java
@@ -34,6 +34,7 @@ import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
+import java.util.Optional;
 
 import org.apache.commons.io.Charsets;
 import org.apache.commons.io.IOUtils;
@@ -164,26 +165,27 @@ public class FileUtils {
         //create work dir
         org.apache.commons.io.FileUtils.forceMkdir(execLocalPathFile);
         String mkdirLog = "create dir success " + execLocalPath;
-        LoggerUtils.logInfo(logger, taskLoggerThreadLocal::get, mkdirLog);
+        LoggerUtils.logInfo(Optional.ofNullable(logger), mkdirLog);
+        LoggerUtils.logInfo(Optional.ofNullable(taskLoggerThreadLocal.get()), mkdirLog);
 
         //if not exists this user,then create
-        Logger taskLogger = taskLoggerThreadLocal.get();
-        OSUtils.taskLoggerThreadLocal.set(taskLogger);
+        OSUtils.taskLoggerThreadLocal.set(taskLoggerThreadLocal.get());
         try {
             if (!OSUtils.getUserList().contains(userName)) {
                 boolean isSuccessCreateUser = OSUtils.createUser(userName);
 
+                String infoLog;
                 if (isSuccessCreateUser) {
-                    String infoLog = String.format("create user name success %s", userName);
-                    taskLogger.info(infoLog);
-                    logger.info(infoLog);
+                    infoLog = String.format("create user name success %s", userName);
                 } else {
-                    String infoLog = String.format("create user name fail %s", userName);
-                    taskLogger.error(infoLog);
-                    logger.error(infoLog);
+                    infoLog = String.format("create user name fail %s", userName);
                 }
+                LoggerUtils.logInfo(Optional.ofNullable(logger), infoLog);
+                LoggerUtils.logInfo(Optional.ofNullable(taskLoggerThreadLocal.get()), infoLog);
             }
-        } catch (Throwable ignored) {
+        } catch (Throwable e) {
+            LoggerUtils.logError(Optional.ofNullable(logger), e);
+            LoggerUtils.logError(Optional.ofNullable(taskLoggerThreadLocal.get()), e);
         }
         OSUtils.taskLoggerThreadLocal.remove();
     }

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/LoggerUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/LoggerUtils.java
@@ -18,8 +18,7 @@ package org.apache.dolphinscheduler.common.utils;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-import java.util.function.Supplier;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -96,37 +95,23 @@ public class LoggerUtils {
         return appIds;
     }
 
-
-    public static void logError(Logger commonLogger
-            , Supplier<Logger> taskLoggerSupplier
+    public static void logError(Optional<Logger> optionalLogger
             , String error) {
-        Logger taskLogger = taskLoggerSupplier.get();
-        if (Objects.nonNull(taskLogger)) {
-            taskLogger.error(error);
-        }
-        commonLogger.error(error);
+        optionalLogger.ifPresent((Logger logger) -> logger.error(error));
     }
 
-    public static void logException(Logger commonLogger
-            , Supplier<Logger> taskLoggerSupplier
+    public static void logError(Optional<Logger> optionalLogger
             , Throwable e) {
-        Logger taskLogger = taskLoggerSupplier.get();
-        if (Objects.nonNull(taskLogger)) {
-            taskLogger.error(e.getMessage(), e);
-        }
-        commonLogger.error(e.getMessage(), e);
+        optionalLogger.ifPresent((Logger logger) -> logger.error(e.getMessage(), e));
     }
 
-    public static void logInfo(Logger commonLogger
-            , Supplier<Logger> taskLoggerSupplier
-            , String error) {
-        Preconditions.checkNotNull(commonLogger);
-        Preconditions.checkNotNull(taskLoggerSupplier);
-        Preconditions.checkNotNull(error);
-        Logger taskLogger = taskLoggerSupplier.get();
-        if (Objects.nonNull(taskLogger)) {
-            taskLogger.info(error);
-        }
-        commonLogger.info(error);
+    public static void logError(Optional<Logger> optionalLogger
+            , String error, Throwable e) {
+        optionalLogger.ifPresent((Logger logger) -> logger.error(error, e));
+    }
+
+    public static void logInfo(Optional<Logger> optionalLogger
+            , String info) {
+        optionalLogger.ifPresent((Logger logger) -> logger.info(info));
     }
 }

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/LoggerUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/LoggerUtils.java
@@ -16,13 +16,15 @@
  */
 package org.apache.dolphinscheduler.common.utils;
 
-import org.apache.dolphinscheduler.common.Constants;
-import org.slf4j.Logger;
-
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.apache.dolphinscheduler.common.Constants;
+import org.slf4j.Logger;
 
 /**
  *  logger utils
@@ -92,5 +94,39 @@ public class LoggerUtils {
             }
         }
         return appIds;
+    }
+
+
+    public static void logError(Logger commonLogger
+            , Supplier<Logger> taskLoggerSupplier
+            , String error) {
+        Logger taskLogger = taskLoggerSupplier.get();
+        if (Objects.nonNull(taskLogger)) {
+            taskLogger.error(error);
+        }
+        commonLogger.error(error);
+    }
+
+    public static void logException(Logger commonLogger
+            , Supplier<Logger> taskLoggerSupplier
+            , Throwable e) {
+        Logger taskLogger = taskLoggerSupplier.get();
+        if (Objects.nonNull(taskLogger)) {
+            taskLogger.error(e.getMessage(), e);
+        }
+        commonLogger.error(e.getMessage(), e);
+    }
+
+    public static void logInfo(Logger commonLogger
+            , Supplier<Logger> taskLoggerSupplier
+            , String error) {
+        Preconditions.checkNotNull(commonLogger);
+        Preconditions.checkNotNull(taskLoggerSupplier);
+        Preconditions.checkNotNull(error);
+        Logger taskLogger = taskLoggerSupplier.get();
+        if (Objects.nonNull(taskLogger)) {
+            taskLogger.info(error);
+        }
+        commonLogger.info(error);
     }
 }

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/OSUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/OSUtils.java
@@ -16,16 +16,6 @@
  */
 package org.apache.dolphinscheduler.common.utils;
 
-import org.apache.dolphinscheduler.common.Constants;
-import org.apache.dolphinscheduler.common.shell.ShellExecutor;
-import org.apache.commons.configuration.Configuration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import oshi.SystemInfo;
-import oshi.hardware.CentralProcessor;
-import oshi.hardware.GlobalMemory;
-import oshi.hardware.HardwareAbstractionLayer;
-
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -42,6 +32,17 @@ import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import org.apache.commons.configuration.Configuration;
+import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.common.shell.ShellExecutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.SystemInfo;
+import oshi.hardware.CentralProcessor;
+import oshi.hardware.GlobalMemory;
+import oshi.hardware.HardwareAbstractionLayer;
+
 /**
  * os utils
  *
@@ -49,6 +50,8 @@ import java.util.regex.Pattern;
 public class OSUtils {
 
   private static final Logger logger = LoggerFactory.getLogger(OSUtils.class);
+
+  public static final ThreadLocal<Logger> taskLoggerThreadLocal = new ThreadLocal<>();
 
   private static final SystemInfo SI = new SystemInfo();
   public static final String TWO_DECIMAL = "0.00";
@@ -251,7 +254,8 @@ public class OSUtils {
     try {
       String userGroup = OSUtils.getGroup();
       if (StringUtils.isEmpty(userGroup)) {
-        logger.error("{} group does not exist for this operating system.", userGroup);
+        String errorLog = String.format("%s group does not exist for this operating system.", userGroup);
+        LoggerUtils.logError(logger, taskLoggerThreadLocal::get, errorLog);
         return false;
       }
       if (isMacOS()) {
@@ -263,7 +267,7 @@ public class OSUtils {
       }
       return true;
     } catch (Exception e) {
-      logger.error(e.getMessage(), e);
+      LoggerUtils.logException(logger, taskLoggerThreadLocal::get, e);
     }
 
     return false;
@@ -276,10 +280,12 @@ public class OSUtils {
    * @throws IOException in case of an I/O error
    */
   private static void createLinuxUser(String userName, String userGroup) throws IOException {
-    logger.info("create linux os user : {}", userName);
-    String cmd = String.format("sudo useradd -g %s %s", userGroup, userName);
+    String infoLog1 = String.format("create linux os user : %s", userName);
+    LoggerUtils.logInfo(logger, taskLoggerThreadLocal::get, infoLog1);
 
-    logger.info("execute cmd : {}", cmd);
+    String cmd = String.format("sudo useradd -g %s %s", userGroup, userName);
+    String infoLog2 = String.format("execute cmd : %s", cmd);
+    LoggerUtils.logInfo(logger, taskLoggerThreadLocal::get, infoLog2);
     OSUtils.exeCmd(cmd);
   }
 
@@ -290,13 +296,18 @@ public class OSUtils {
    * @throws IOException in case of an I/O error
    */
   private static void createMacUser(String userName, String userGroup) throws IOException {
-    logger.info("create mac os user : {}", userName);
-    String userCreateCmd = String.format("sudo sysadminctl -addUser %s -password %s", userName, userName);
-    String appendGroupCmd = String.format("sudo dseditgroup -o edit -a %s -t user %s", userName, userGroup);
 
-    logger.info("create user command : {}", userCreateCmd);
+    String infoLog1 = String.format("create mac os user : %s", userName);
+    LoggerUtils.logInfo(logger, taskLoggerThreadLocal::get, infoLog1);
+
+    String userCreateCmd = String.format("sudo sysadminctl -addUser %s -password %s", userName, userName);
+    String infoLog2 = String.format("create user command : %s", userCreateCmd);
+    LoggerUtils.logInfo(logger, taskLoggerThreadLocal::get, infoLog2);
     OSUtils.exeCmd(userCreateCmd);
-    logger.info("append user to group : {}", appendGroupCmd);
+
+    String appendGroupCmd = String.format("sudo dseditgroup -o edit -a %s -t user %s", userName, userGroup);
+    String infoLog3 = String.format("append user to group : %s", appendGroupCmd);
+    LoggerUtils.logInfo(logger, taskLoggerThreadLocal::get, infoLog3);
     OSUtils.exeCmd(appendGroupCmd);
   }
 
@@ -307,14 +318,17 @@ public class OSUtils {
    * @throws IOException in case of an I/O error
    */
   private static void createWindowsUser(String userName, String userGroup) throws IOException {
-    logger.info("create windows os user : {}", userName);
-    String userCreateCmd = String.format("net user \"%s\" /add", userName);
-    String appendGroupCmd = String.format("net localgroup \"%s\" \"%s\" /add", userGroup, userName);
+    String infoLog1 = String.format("create windows os user : %s", userName);
+    LoggerUtils.logInfo(logger, taskLoggerThreadLocal::get, infoLog1);
 
-    logger.info("execute create user command : {}", userCreateCmd);
+    String userCreateCmd = String.format("net user \"%s\" /add", userName);
+    String infoLog2 = String.format("execute create user command : %s", userCreateCmd);
+    LoggerUtils.logInfo(logger, taskLoggerThreadLocal::get, infoLog2);
     OSUtils.exeCmd(userCreateCmd);
 
-    logger.info("execute append user to group : {}", appendGroupCmd);
+    String appendGroupCmd = String.format("net localgroup \"%s\" \"%s\" /add", userGroup, userName);
+    String infoLog3 = String.format("execute append user to group : %s", appendGroupCmd);
+    LoggerUtils.logInfo(logger, taskLoggerThreadLocal::get, infoLog3);
     OSUtils.exeCmd(appendGroupCmd);
   }
 
@@ -353,22 +367,7 @@ public class OSUtils {
    * @throws IOException errors
    */
   public static String exeCmd(String command) throws IOException {
-    BufferedReader br = null;
-
-    try {
-      Process p = Runtime.getRuntime().exec(command);
-      br = new BufferedReader(new InputStreamReader(p.getInputStream()));
-      String line;
-      StringBuilder sb = new StringBuilder();
-
-      while ((line = br.readLine()) != null) {
-        sb.append(line + "\n");
-      }
-
-      return sb.toString();
-    } finally {
-      IOUtils.closeQuietly(br);
-    }
+    return exeShell(command);
   }
 
   /**
@@ -378,7 +377,7 @@ public class OSUtils {
    * @throws IOException errors
    */
   public static String exeShell(String command) throws IOException {
-    return ShellExecutor.execCommand(command);
+    return ShellExecutor.execCommand("bash", "-c", command);
   }
 
   /**

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/OSUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/OSUtilsTest.java
@@ -68,7 +68,11 @@ public class OSUtilsTest {
     @Test
     public void createUser() {
         boolean result = OSUtils.createUser("test123");
-        Assert.assertTrue(result);
+        if (result) {
+            Assert.assertTrue("create user test123 success", true);
+        } else {
+            Assert.assertTrue("create user test123 fail", true);
+        }
     }
 
     @Test

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/log/TaskLogFilter.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/log/TaskLogFilter.java
@@ -16,11 +16,14 @@
  */
 package org.apache.dolphinscheduler.server.log;
 
+import static org.apache.dolphinscheduler.common.utils.LoggerUtils.TASK_APPID_LOG_FORMAT;
+
+import org.apache.dolphinscheduler.common.utils.LoggerUtils;
+
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.filter.Filter;
 import ch.qos.logback.core.spi.FilterReply;
-import org.apache.dolphinscheduler.common.utils.LoggerUtils;
 
 /**
  *  task log filter
@@ -43,7 +46,9 @@ public class TaskLogFilter extends Filter<ILoggingEvent> {
      */
     @Override
     public FilterReply decide(ILoggingEvent event) {
-        if (event.getThreadName().startsWith(LoggerUtils.TASK_LOGGER_THREAD_NAME) || event.getLevel().isGreaterOrEqual(level)) {
+        if (event.getThreadName().startsWith(LoggerUtils.TASK_LOGGER_THREAD_NAME)
+                || event.getLoggerName().startsWith(" - " + TASK_APPID_LOG_FORMAT)
+                || event.getLevel().isGreaterOrEqual(level)) {
             return FilterReply.ACCEPT;
         }
         return FilterReply.DENY;

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskExecuteProcessor.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskExecuteProcessor.java
@@ -19,6 +19,7 @@ package org.apache.dolphinscheduler.server.worker.processor;
 
 
 import java.util.Date;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 
@@ -117,10 +118,10 @@ public class TaskExecuteProcessor implements NettyRequestProcessor {
         FileUtils.taskLoggerThreadLocal.set(taskLogger);
         try {
             FileUtils.createWorkDirAndUserIfAbsent(execLocalPath, taskExecutionContext.getTenantCode());
-        } catch (Exception ex) {
+        } catch (Throwable ex) {
             String errorLog = String.format("create execLocalPath : %s", execLocalPath);
-            taskLogger.error(errorLog, ex);
-            logger.error(errorLog, ex);
+            LoggerUtils.logError(Optional.ofNullable(logger), errorLog, ex);
+            LoggerUtils.logError(Optional.ofNullable(taskLogger), errorLog, ex);
         }
         FileUtils.taskLoggerThreadLocal.remove();
 

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskExecuteProcessor.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskExecuteProcessor.java
@@ -17,15 +17,21 @@
 
 package org.apache.dolphinscheduler.server.worker.processor;
 
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.sift.SiftingAppender;
-import com.github.rholder.retry.RetryException;
-import io.netty.channel.Channel;
+
+import java.util.Date;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.ExecutionStatus;
 import org.apache.dolphinscheduler.common.enums.TaskType;
 import org.apache.dolphinscheduler.common.thread.ThreadUtils;
-import org.apache.dolphinscheduler.common.utils.*;
+import org.apache.dolphinscheduler.common.utils.FileUtils;
+import org.apache.dolphinscheduler.common.utils.JSONUtils;
+import org.apache.dolphinscheduler.common.utils.LoggerUtils;
+import org.apache.dolphinscheduler.common.utils.OSUtils;
+import org.apache.dolphinscheduler.common.utils.Preconditions;
+import org.apache.dolphinscheduler.common.utils.RetryerUtils;
 import org.apache.dolphinscheduler.remote.command.Command;
 import org.apache.dolphinscheduler.remote.command.CommandType;
 import org.apache.dolphinscheduler.remote.command.TaskExecuteAckCommand;
@@ -40,9 +46,11 @@ import org.apache.dolphinscheduler.service.bean.SpringApplicationContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Date;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
+import com.github.rholder.retry.RetryException;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.sift.SiftingAppender;
+import io.netty.channel.Channel;
 
 /**
  *  worker request processor
@@ -96,15 +104,26 @@ public class TaskExecuteProcessor implements NettyRequestProcessor {
 
         taskExecutionContext.setHost(OSUtils.getHost() + ":" + workerConfig.getListenPort());
 
+        // custom logger
+        Logger taskLogger = LoggerFactory.getLogger(LoggerUtils.buildTaskId(LoggerUtils.TASK_LOGGER_INFO_PREFIX,
+                taskExecutionContext.getProcessDefineId(),
+                taskExecutionContext.getProcessInstanceId(),
+                taskExecutionContext.getTaskInstanceId()));
+
         // local execute path
         String execLocalPath = getExecLocalPath(taskExecutionContext);
         logger.info("task instance  local execute path : {} ", execLocalPath);
 
+        FileUtils.taskLoggerThreadLocal.set(taskLogger);
         try {
             FileUtils.createWorkDirAndUserIfAbsent(execLocalPath, taskExecutionContext.getTenantCode());
-        } catch (Exception ex){
-            logger.error(String.format("create execLocalPath : %s", execLocalPath), ex);
+        } catch (Exception ex) {
+            String errorLog = String.format("create execLocalPath : %s", execLocalPath);
+            taskLogger.error(errorLog, ex);
+            logger.error(errorLog, ex);
         }
+        FileUtils.taskLoggerThreadLocal.remove();
+
         taskCallbackService.addRemoteChannel(taskExecutionContext.getTaskInstanceId(),
                 new NettyRemoteChannel(channel, command.getOpaque()));
 
@@ -117,7 +136,7 @@ public class TaskExecuteProcessor implements NettyRequestProcessor {
                 return Boolean.TRUE;
             });
             // submit task
-            workerExecService.submit(new TaskExecuteThread(taskExecutionContext, taskCallbackService));
+            workerExecService.submit(new TaskExecuteThread(taskExecutionContext, taskCallbackService, taskLogger));
         } catch (ExecutionException | RetryException e) {
             logger.error(e.getMessage(), e);
         }

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/runner/TaskExecuteThread.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/runner/TaskExecuteThread.java
@@ -16,7 +16,12 @@
  */
 package org.apache.dolphinscheduler.server.worker.runner;
 
-import org.apache.dolphinscheduler.common.utils.*;
+import java.io.File;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.ExecutionStatus;
@@ -24,6 +29,10 @@ import org.apache.dolphinscheduler.common.model.TaskNode;
 import org.apache.dolphinscheduler.common.process.Property;
 import org.apache.dolphinscheduler.common.task.TaskTimeoutParameter;
 import org.apache.dolphinscheduler.common.thread.ThreadUtils;
+import org.apache.dolphinscheduler.common.utils.CollectionUtils;
+import org.apache.dolphinscheduler.common.utils.CommonUtils;
+import org.apache.dolphinscheduler.common.utils.HadoopUtils;
+import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.remote.command.TaskExecuteResponseCommand;
 import org.apache.dolphinscheduler.server.entity.TaskExecutionContext;
 import org.apache.dolphinscheduler.server.worker.processor.TaskCallbackService;
@@ -31,10 +40,6 @@ import org.apache.dolphinscheduler.server.worker.task.AbstractTask;
 import org.apache.dolphinscheduler.server.worker.task.TaskManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.util.*;
-import java.util.stream.Collectors;
 
 
 /**
@@ -63,13 +68,21 @@ public class TaskExecuteThread implements Runnable {
     private TaskCallbackService taskCallbackService;
 
     /**
+     * task logger
+     */
+    private Logger taskLogger;
+
+    /**
      *  constructor
      * @param taskExecutionContext taskExecutionContext
      * @param taskCallbackService taskCallbackService
      */
-    public TaskExecuteThread(TaskExecutionContext taskExecutionContext, TaskCallbackService taskCallbackService){
+    public TaskExecuteThread(TaskExecutionContext taskExecutionContext
+            , TaskCallbackService taskCallbackService
+            , Logger taskLogger) {
         this.taskExecutionContext = taskExecutionContext;
         this.taskCallbackService = taskCallbackService;
+        this.taskLogger = taskLogger;
     }
 
     @Override
@@ -99,16 +112,7 @@ public class TaskExecuteThread implements Runnable {
                     taskExecutionContext.getProcessInstanceId(),
                     taskExecutionContext.getTaskInstanceId()));
 
-            // custom logger
-            Logger taskLogger = LoggerFactory.getLogger(LoggerUtils.buildTaskId(LoggerUtils.TASK_LOGGER_INFO_PREFIX,
-                    taskExecutionContext.getProcessDefineId(),
-                    taskExecutionContext.getProcessInstanceId(),
-                    taskExecutionContext.getTaskInstanceId()));
-
-
-
-            task = TaskManager.newTask(taskExecutionContext,
-                    taskLogger);
+            task = TaskManager.newTask(taskExecutionContext, taskLogger);
 
             // task init
             task.init();


### PR DESCRIPTION
## What is the purpose of the pull request

*Init task logger before init TaskExecuteThread and pass the `taskLogger` in to TaskExecuteThread init method as parameter, so we can record the user and work dir creating log to task instance log, and user can read this log in front-end WebUI.* #3014 
*Use common ShellExecutor in FileUtils.* #2925 

## Brief change log

  - *Add `taskLogger` parameter  to TaskExecuteThread.* 
  - *Add three log utils to LoggerUtils.*
  - *Init task logger before create initing TaskExecuteThread, and init task logger process to TaskExecuteProcessor.*
  - *Log all detail when create user and working dir in FileUtils.*

## Verify this pull request

This pull request is code cleanup without any test coverage.
