### PR TITLE
rename 'Remoting' to 'Remote' to make it standard and reasonable

### DIFF
--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/NettyRemoteClient.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/NettyRemoteClient.java
@@ -47,11 +47,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- *  remoting netty client
+ *  remote netty client
  */
-public class NettyRemotingClient {
+public class NettyRemoteClient {
 
-    private final Logger logger = LoggerFactory.getLogger(NettyRemotingClient.class);
+    private final Logger logger = LoggerFactory.getLogger(NettyRemoteClient.class);
 
     /**
      * client bootstrap
@@ -107,7 +107,7 @@ public class NettyRemotingClient {
      *  client init
      * @param clientConfig client config
      */
-    public NettyRemotingClient(final NettyClientConfig clientConfig){
+    public NettyRemoteClient(final NettyClientConfig clientConfig){
         this.clientConfig = clientConfig;
         this.workerGroup = new NioEventLoopGroup(clientConfig.getWorkerThreads(), new ThreadFactory() {
             private AtomicInteger threadIndex = new AtomicInteger(0);

--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/NettyRemoteServer.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/NettyRemoteServer.java
@@ -42,11 +42,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- *  remoting netty server
+ *  remote netty server
  */
-public class NettyRemotingServer {
+public class NettyRemoteServer {
 
-    private final Logger logger = LoggerFactory.getLogger(NettyRemotingServer.class);
+    private final Logger logger = LoggerFactory.getLogger(NettyRemoteServer.class);
 
     /**
      *  server bootstrap
@@ -93,7 +93,7 @@ public class NettyRemotingServer {
      *
      * @param serverConfig server config
      */
-    public NettyRemotingServer(final NettyServerConfig serverConfig){
+    public NettyRemoteServer(final NettyServerConfig serverConfig){
         this.serverConfig = serverConfig;
 
         this.bossGroup = new NioEventLoopGroup(1, new ThreadFactory() {

--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/handler/NettyClientHandler.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/handler/NettyClientHandler.java
@@ -17,7 +17,7 @@
 package org.apache.dolphinscheduler.remote.handler;
 
 import io.netty.channel.*;
-import org.apache.dolphinscheduler.remote.NettyRemotingClient;
+import org.apache.dolphinscheduler.remote.NettyRemoteClient;
 import org.apache.dolphinscheduler.remote.command.Command;
 import org.apache.dolphinscheduler.remote.command.CommandType;
 import org.apache.dolphinscheduler.remote.future.ResponseFuture;
@@ -44,7 +44,7 @@ public class NettyClientHandler extends ChannelInboundHandlerAdapter {
     /**
      *  netty client
      */
-    private final NettyRemotingClient nettyRemotingClient;
+    private final NettyRemoteClient nettyRemoteClient;
 
     /**
      *  callback thread executor
@@ -61,8 +61,8 @@ public class NettyClientHandler extends ChannelInboundHandlerAdapter {
      */
     private final ExecutorService defaultExecutor = Executors.newFixedThreadPool(Constants.CPUS);
 
-    public NettyClientHandler(NettyRemotingClient nettyRemotingClient, ExecutorService callbackExecutor){
-        this.nettyRemotingClient = nettyRemotingClient;
+    public NettyClientHandler(NettyRemoteClient nettyRemoteClient, ExecutorService callbackExecutor){
+        this.nettyRemoteClient = nettyRemoteClient;
         this.callbackExecutor = callbackExecutor;
         this.processors = new ConcurrentHashMap();
     }
@@ -76,7 +76,7 @@ public class NettyClientHandler extends ChannelInboundHandlerAdapter {
      */
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-        nettyRemotingClient.closeChannel(ChannelUtils.toAddress(ctx.channel()));
+        nettyRemoteClient.closeChannel(ChannelUtils.toAddress(ctx.channel()));
         ctx.channel().close();
     }
 
@@ -171,7 +171,7 @@ public class NettyClientHandler extends ChannelInboundHandlerAdapter {
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         logger.error("exceptionCaught : {}", cause);
-        nettyRemotingClient.closeChannel(ChannelUtils.toAddress(ctx.channel()));
+        nettyRemoteClient.closeChannel(ChannelUtils.toAddress(ctx.channel()));
         ctx.channel().close();
     }
 

--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/handler/NettyServerHandler.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/handler/NettyServerHandler.java
@@ -18,7 +18,7 @@
 package org.apache.dolphinscheduler.remote.handler;
 
 import io.netty.channel.*;
-import org.apache.dolphinscheduler.remote.NettyRemotingServer;
+import org.apache.dolphinscheduler.remote.NettyRemoteServer;
 import org.apache.dolphinscheduler.remote.command.Command;
 import org.apache.dolphinscheduler.remote.command.CommandType;
 import org.apache.dolphinscheduler.remote.processor.NettyRequestProcessor;
@@ -42,15 +42,15 @@ public class NettyServerHandler extends ChannelInboundHandlerAdapter {
     /**
      *  netty remote server
      */
-    private final NettyRemotingServer nettyRemotingServer;
+    private final NettyRemoteServer nettyRemoteServer;
 
     /**
      *  server processors queue
      */
     private final ConcurrentHashMap<CommandType, Pair<NettyRequestProcessor, ExecutorService>> processors = new ConcurrentHashMap();
 
-    public NettyServerHandler(NettyRemotingServer nettyRemotingServer){
-        this.nettyRemotingServer = nettyRemotingServer;
+    public NettyServerHandler(NettyRemoteServer nettyRemoteServer){
+        this.nettyRemoteServer = nettyRemoteServer;
     }
 
     /**
@@ -96,7 +96,7 @@ public class NettyServerHandler extends ChannelInboundHandlerAdapter {
     public void registerProcessor(final CommandType commandType, final NettyRequestProcessor processor, final ExecutorService executor) {
         ExecutorService executorRef = executor;
         if(executorRef == null){
-            executorRef = nettyRemotingServer.getDefaultExecutor();
+            executorRef = nettyRemoteServer.getDefaultExecutor();
         }
         this.processors.putIfAbsent(commandType, new Pair<>(processor, executorRef));
     }

--- a/dolphinscheduler-remote/src/test/java/org/apache/dolphinscheduler/remote/NettyRemoteClientTest.java
+++ b/dolphinscheduler-remote/src/test/java/org/apache/dolphinscheduler/remote/NettyRemoteClientTest.java
@@ -37,7 +37,7 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  *  netty remote client test
  */
-public class NettyRemotingClientTest {
+public class NettyRemoteClientTest {
 
 
     /**
@@ -47,7 +47,7 @@ public class NettyRemotingClientTest {
     public void testSendSync(){
         NettyServerConfig serverConfig = new NettyServerConfig();
 
-        NettyRemotingServer server = new NettyRemotingServer(serverConfig);
+        NettyRemoteServer server = new NettyRemoteServer(serverConfig);
         server.registerProcessor(CommandType.PING, new NettyRequestProcessor() {
             @Override
             public void process(Channel channel, Command command) {
@@ -59,7 +59,7 @@ public class NettyRemotingClientTest {
         server.start();
         //
         final NettyClientConfig clientConfig = new NettyClientConfig();
-        NettyRemotingClient client = new NettyRemotingClient(clientConfig);
+        NettyRemoteClient client = new NettyRemoteClient(clientConfig);
         Command commandPing = Ping.create();
         try {
             Command response = client.sendSync(new Host("127.0.0.1", serverConfig.getListenPort()), commandPing, 2000);
@@ -78,7 +78,7 @@ public class NettyRemotingClientTest {
     public void testSendAsync(){
         NettyServerConfig serverConfig = new NettyServerConfig();
 
-        NettyRemotingServer server = new NettyRemotingServer(serverConfig);
+        NettyRemoteServer server = new NettyRemoteServer(serverConfig);
         server.registerProcessor(CommandType.PING, new NettyRequestProcessor() {
             @Override
             public void process(Channel channel, Command command) {
@@ -88,7 +88,7 @@ public class NettyRemotingClientTest {
         server.start();
         //
         final NettyClientConfig clientConfig = new NettyClientConfig();
-        NettyRemotingClient client = new NettyRemotingClient(clientConfig);
+        NettyRemoteClient client = new NettyRemoteClient(clientConfig);
         CountDownLatch latch = new CountDownLatch(1);
         Command commandPing = Ping.create();
         try {

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/log/LoggerServer.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/log/LoggerServer.java
@@ -19,7 +19,7 @@ package org.apache.dolphinscheduler.server.log;
 
 
 import org.apache.dolphinscheduler.common.Constants;
-import org.apache.dolphinscheduler.remote.NettyRemotingServer;
+import org.apache.dolphinscheduler.remote.NettyRemoteServer;
 import org.apache.dolphinscheduler.remote.command.CommandType;
 import org.apache.dolphinscheduler.remote.config.NettyServerConfig;
 import org.slf4j.Logger;
@@ -35,7 +35,7 @@ public class LoggerServer {
     /**
      *  netty server
      */
-    private final NettyRemotingServer server;
+    private final NettyRemoteServer server;
 
     /**
      *  netty server config
@@ -50,7 +50,7 @@ public class LoggerServer {
     public LoggerServer(){
         this.serverConfig = new NettyServerConfig();
         this.serverConfig.setListenPort(Constants.RPC_PORT);
-        this.server = new NettyRemotingServer(serverConfig);
+        this.server = new NettyRemoteServer(serverConfig);
         this.requestProcessor = new LoggerRequestProcessor();
         this.server.registerProcessor(CommandType.GET_LOG_BYTES_REQUEST, requestProcessor, requestProcessor.getExecutor());
         this.server.registerProcessor(CommandType.ROLL_VIEW_LOG_REQUEST, requestProcessor, requestProcessor.getExecutor());

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/MasterServer.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/MasterServer.java
@@ -18,7 +18,7 @@ package org.apache.dolphinscheduler.server.master;
 
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.thread.Stopper;
-import org.apache.dolphinscheduler.remote.NettyRemotingServer;
+import org.apache.dolphinscheduler.remote.NettyRemoteServer;
 import org.apache.dolphinscheduler.remote.command.CommandType;
 import org.apache.dolphinscheduler.remote.config.NettyServerConfig;
 import org.apache.dolphinscheduler.server.master.config.MasterConfig;
@@ -71,7 +71,7 @@ public class MasterServer {
     /**
      * netty remote server
      */
-    private NettyRemotingServer nettyRemotingServer;
+    private NettyRemoteServer nettyRemoteServer;
 
     /**
      * master registry
@@ -108,14 +108,14 @@ public class MasterServer {
     @PostConstruct
     public void run(){
 
-        //init remoting server
+        //init remote server
         NettyServerConfig serverConfig = new NettyServerConfig();
         serverConfig.setListenPort(masterConfig.getListenPort());
-        this.nettyRemotingServer = new NettyRemotingServer(serverConfig);
-        this.nettyRemotingServer.registerProcessor(CommandType.TASK_EXECUTE_RESPONSE, new TaskResponseProcessor());
-        this.nettyRemotingServer.registerProcessor(CommandType.TASK_EXECUTE_ACK, new TaskAckProcessor());
-        this.nettyRemotingServer.registerProcessor(CommandType.TASK_KILL_RESPONSE, new TaskKillResponseProcessor());
-        this.nettyRemotingServer.start();
+        this.nettyRemoteServer = new NettyRemoteServer(serverConfig);
+        this.nettyRemoteServer.registerProcessor(CommandType.TASK_EXECUTE_RESPONSE, new TaskResponseProcessor());
+        this.nettyRemoteServer.registerProcessor(CommandType.TASK_EXECUTE_ACK, new TaskAckProcessor());
+        this.nettyRemoteServer.registerProcessor(CommandType.TASK_KILL_RESPONSE, new TaskKillResponseProcessor());
+        this.nettyRemoteServer.start();
 
         // register
         this.masterRegistry.registry();
@@ -177,7 +177,7 @@ public class MasterServer {
             }
             //
             this.masterSchedulerService.close();
-            this.nettyRemotingServer.close();
+            this.nettyRemoteServer.close();
             this.masterRegistry.unRegistry();
             this.zkMasterClient.close();
             //close quartz

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/dispatch/executor/NettyExecutorManager.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/dispatch/executor/NettyExecutorManager.java
@@ -17,7 +17,7 @@
 
 package org.apache.dolphinscheduler.server.master.dispatch.executor;
 
-import org.apache.dolphinscheduler.remote.NettyRemotingClient;
+import org.apache.dolphinscheduler.remote.NettyRemoteClient;
 import org.apache.dolphinscheduler.remote.command.Command;
 import org.apache.dolphinscheduler.remote.command.CommandType;
 import org.apache.dolphinscheduler.remote.config.NettyClientConfig;
@@ -54,14 +54,14 @@ public class NettyExecutorManager extends AbstractExecutorManager<Boolean>{
     /**
      * netty remote client
      */
-    private final NettyRemotingClient nettyRemotingClient;
+    private final NettyRemoteClient nettyRemoteClient;
 
     /**
      * constructor
      */
     public NettyExecutorManager(){
         final NettyClientConfig clientConfig = new NettyClientConfig();
-        this.nettyRemotingClient = new NettyRemotingClient(clientConfig);
+        this.nettyRemoteClient = new NettyRemoteClient(clientConfig);
     }
 
     @PostConstruct
@@ -70,9 +70,9 @@ public class NettyExecutorManager extends AbstractExecutorManager<Boolean>{
          * register EXECUTE_TASK_RESPONSE command type TaskResponseProcessor
          * register EXECUTE_TASK_ACK command type TaskAckProcessor
          */
-        this.nettyRemotingClient.registerProcessor(CommandType.TASK_EXECUTE_RESPONSE, new TaskResponseProcessor());
-        this.nettyRemotingClient.registerProcessor(CommandType.TASK_EXECUTE_ACK, new TaskAckProcessor());
-        this.nettyRemotingClient.registerProcessor(CommandType.TASK_KILL_RESPONSE, new TaskKillResponseProcessor());
+        this.nettyRemoteClient.registerProcessor(CommandType.TASK_EXECUTE_RESPONSE, new TaskResponseProcessor());
+        this.nettyRemoteClient.registerProcessor(CommandType.TASK_EXECUTE_ACK, new TaskAckProcessor());
+        this.nettyRemoteClient.registerProcessor(CommandType.TASK_KILL_RESPONSE, new TaskKillResponseProcessor());
     }
 
     /**
@@ -140,7 +140,7 @@ public class NettyExecutorManager extends AbstractExecutorManager<Boolean>{
         boolean success = false;
         do {
             try {
-                nettyRemotingClient.send(host, command);
+                nettyRemoteClient.send(host, command);
                 success = true;
             } catch (Exception ex) {
                 logger.error(String.format("send command : %s to %s error", command, host), ex);
@@ -180,7 +180,7 @@ public class NettyExecutorManager extends AbstractExecutorManager<Boolean>{
         return nodes;
     }
 
-    public NettyRemotingClient getNettyRemotingClient() {
-        return nettyRemotingClient;
+    public NettyRemoteClient getNettyRemoteClient() {
+        return nettyRemoteClient;
     }
 }

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterExecThread.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterExecThread.java
@@ -32,7 +32,7 @@ import org.apache.dolphinscheduler.dao.entity.ProcessInstance;
 import org.apache.dolphinscheduler.dao.entity.Schedule;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.dao.utils.DagHelper;
-import org.apache.dolphinscheduler.remote.NettyRemotingClient;
+import org.apache.dolphinscheduler.remote.NettyRemoteClient;
 import org.apache.dolphinscheduler.server.master.config.MasterConfig;
 import org.apache.dolphinscheduler.server.utils.AlertManager;
 import org.apache.dolphinscheduler.service.bean.SpringApplicationContext;
@@ -143,15 +143,15 @@ public class MasterExecThread implements Runnable {
     /**
      *
      */
-    private NettyRemotingClient nettyRemotingClient;
+    private NettyRemoteClient nettyRemoteClient;
 
     /**
      * constructor of MasterExecThread
      * @param processInstance processInstance
      * @param processService processService
-     * @param nettyRemotingClient nettyRemotingClient
+     * @param nettyRemoteClient nettyRemotingClient
      */
-    public MasterExecThread(ProcessInstance processInstance, ProcessService processService, NettyRemotingClient nettyRemotingClient){
+    public MasterExecThread(ProcessInstance processInstance, ProcessService processService, NettyRemoteClient nettyRemoteClient){
         this.processService = processService;
 
         this.processInstance = processInstance;
@@ -159,7 +159,7 @@ public class MasterExecThread implements Runnable {
         int masterTaskExecNum = masterConfig.getMasterExecTaskNum();
         this.taskExecService = ThreadUtils.newDaemonFixedThreadExecutor("Master-Task-Exec-Thread",
                 masterTaskExecNum);
-        this.nettyRemotingClient = nettyRemotingClient;
+        this.nettyRemoteClient = nettyRemoteClient;
     }
 
 

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterSchedulerService.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterSchedulerService.java
@@ -24,7 +24,7 @@ import org.apache.dolphinscheduler.common.thread.ThreadUtils;
 import org.apache.dolphinscheduler.common.utils.OSUtils;
 import org.apache.dolphinscheduler.dao.entity.Command;
 import org.apache.dolphinscheduler.dao.entity.ProcessInstance;
-import org.apache.dolphinscheduler.remote.NettyRemotingClient;
+import org.apache.dolphinscheduler.remote.NettyRemoteClient;
 import org.apache.dolphinscheduler.remote.config.NettyClientConfig;
 import org.apache.dolphinscheduler.server.master.config.MasterConfig;
 import org.apache.dolphinscheduler.server.zk.ZKMasterClient;
@@ -68,9 +68,9 @@ public class MasterSchedulerService extends Thread {
     private MasterConfig masterConfig;
 
     /**
-     *  netty remoting client
+     *  netty remote client
      */
-    private NettyRemotingClient nettyRemotingClient;
+    private NettyRemoteClient nettyRemoteClient;
 
     /**
      * master exec service
@@ -85,7 +85,7 @@ public class MasterSchedulerService extends Thread {
     public void init(){
         this.masterExecService = (ThreadPoolExecutor)ThreadUtils.newDaemonFixedThreadExecutor("Master-Exec-Thread", masterConfig.getMasterExecThreads());
         NettyClientConfig clientConfig = new NettyClientConfig();
-        this.nettyRemotingClient = new NettyRemotingClient(clientConfig);
+        this.nettyRemoteClient = new NettyRemoteClient(clientConfig);
     }
 
     @Override
@@ -103,7 +103,7 @@ public class MasterSchedulerService extends Thread {
         if(!terminated){
             logger.warn("masterExecService shutdown without terminated, increase await time");
         }
-        nettyRemotingClient.close();
+        nettyRemoteClient.close();
         logger.info("master schedule service stopped...");
     }
 
@@ -138,7 +138,7 @@ public class MasterSchedulerService extends Thread {
                                     this.masterConfig.getMasterExecThreads() - activeCount, command);
                             if (processInstance != null) {
                                 logger.info("start master exec thread , split DAG ...");
-                                masterExecService.execute(new MasterExecThread(processInstance, processService, nettyRemotingClient));
+                                masterExecService.execute(new MasterExecThread(processInstance, processService, nettyRemoteClient));
                             }
                         }catch (Exception e){
                             logger.error("scan command error ", e);

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/WorkerServer.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/WorkerServer.java
@@ -18,7 +18,7 @@ package org.apache.dolphinscheduler.server.worker;
 
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.thread.Stopper;
-import org.apache.dolphinscheduler.remote.NettyRemotingServer;
+import org.apache.dolphinscheduler.remote.NettyRemoteServer;
 import org.apache.dolphinscheduler.remote.command.CommandType;
 import org.apache.dolphinscheduler.remote.config.NettyServerConfig;
 import org.apache.dolphinscheduler.server.worker.config.WorkerConfig;
@@ -49,7 +49,7 @@ public class WorkerServer {
     /**
      *  netty remote server
      */
-    private NettyRemotingServer nettyRemotingServer;
+    private NettyRemoteServer nettyRemoteServer;
 
     /**
      *  worker registry
@@ -89,13 +89,13 @@ public class WorkerServer {
     public void run(){
         logger.info("start worker server...");
 
-        //init remoting server
+        //init remote server
         NettyServerConfig serverConfig = new NettyServerConfig();
         serverConfig.setListenPort(workerConfig.getListenPort());
-        this.nettyRemotingServer = new NettyRemotingServer(serverConfig);
-        this.nettyRemotingServer.registerProcessor(CommandType.TASK_EXECUTE_REQUEST, new TaskExecuteProcessor());
-        this.nettyRemotingServer.registerProcessor(CommandType.TASK_KILL_REQUEST, new TaskKillProcessor());
-        this.nettyRemotingServer.start();
+        this.nettyRemoteServer = new NettyRemoteServer(serverConfig);
+        this.nettyRemoteServer.registerProcessor(CommandType.TASK_EXECUTE_REQUEST, new TaskExecuteProcessor());
+        this.nettyRemoteServer.registerProcessor(CommandType.TASK_KILL_REQUEST, new TaskKillProcessor());
+        this.nettyRemoteServer.start();
 
         // worker registry
         this.workerRegistry.registry();
@@ -131,7 +131,7 @@ public class WorkerServer {
                 logger.warn("thread sleep exception", e);
             }
 
-            this.nettyRemotingServer.close();
+            this.nettyRemoteServer.close();
             this.workerRegistry.unRegistry();
 
         } catch (Exception e) {

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskCallbackService.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskCallbackService.java
@@ -24,7 +24,7 @@ import io.netty.channel.ChannelFutureListener;
 import org.apache.dolphinscheduler.common.thread.Stopper;
 import org.apache.dolphinscheduler.common.thread.ThreadUtils;
 import org.apache.dolphinscheduler.common.utils.CollectionUtils;
-import org.apache.dolphinscheduler.remote.NettyRemotingClient;
+import org.apache.dolphinscheduler.remote.NettyRemoteClient;
 import org.apache.dolphinscheduler.remote.command.Command;
 import org.apache.dolphinscheduler.remote.config.NettyClientConfig;
 import org.apache.dolphinscheduler.remote.utils.Host;
@@ -59,14 +59,14 @@ public class TaskCallbackService {
     private ZookeeperRegistryCenter zookeeperRegistryCenter;
 
     /**
-     * netty remoting client
+     * netty remote client
      */
-    private final NettyRemotingClient nettyRemotingClient;
+    private final NettyRemoteClient nettyRemoteClient;
 
 
     public TaskCallbackService(){
         final NettyClientConfig clientConfig = new NettyClientConfig();
-        this.nettyRemotingClient = new NettyRemotingClient(clientConfig);
+        this.nettyRemoteClient = new NettyRemoteClient(clientConfig);
     }
 
     /**
@@ -91,7 +91,7 @@ public class TaskCallbackService {
         if(nettyRemoteChannel.isActive()){
             return nettyRemoteChannel;
         }
-        Channel newChannel = nettyRemotingClient.getChannel(nettyRemoteChannel.getHost());
+        Channel newChannel = nettyRemoteClient.getChannel(nettyRemoteChannel.getHost());
         if(newChannel != null){
             return getRemoteChannel(newChannel, nettyRemoteChannel.getOpaque(), taskInstanceId);
         }
@@ -107,7 +107,7 @@ public class TaskCallbackService {
             }
         }
         for(String masterNode : masterNodes){
-            newChannel = nettyRemotingClient.getChannel(Host.of(masterNode));
+            newChannel = nettyRemoteClient.getChannel(Host.of(masterNode));
             if(newChannel != null){
                 return getRemoteChannel(newChannel, nettyRemoteChannel.getOpaque(), taskInstanceId);
             }

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/dispatch/ExecutorDispatcherTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/dispatch/ExecutorDispatcherTest.java
@@ -17,7 +17,7 @@
 package org.apache.dolphinscheduler.server.master.dispatch;
 
 
-import org.apache.dolphinscheduler.remote.NettyRemotingServer;
+import org.apache.dolphinscheduler.remote.NettyRemoteServer;
 import org.apache.dolphinscheduler.remote.config.NettyServerConfig;
 import org.apache.dolphinscheduler.server.master.dispatch.context.ExecutionContext;
 import org.apache.dolphinscheduler.server.master.dispatch.exceptions.ExecuteException;
@@ -69,9 +69,9 @@ public class ExecutorDispatcherTest {
         int port = 30000;
         final NettyServerConfig serverConfig = new NettyServerConfig();
         serverConfig.setListenPort(port);
-        NettyRemotingServer nettyRemotingServer = new NettyRemotingServer(serverConfig);
-        nettyRemotingServer.registerProcessor(org.apache.dolphinscheduler.remote.command.CommandType.TASK_EXECUTE_REQUEST, Mockito.mock(TaskExecuteProcessor.class));
-        nettyRemotingServer.start();
+        NettyRemoteServer nettyRemoteServer = new NettyRemoteServer(serverConfig);
+        nettyRemoteServer.registerProcessor(org.apache.dolphinscheduler.remote.command.CommandType.TASK_EXECUTE_REQUEST, Mockito.mock(TaskExecuteProcessor.class));
+        nettyRemoteServer.start();
         //
         workerConfig.setListenPort(port);
         workerRegistry.registry();

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/dispatch/executor/NettyExecutorManagerTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/dispatch/executor/NettyExecutorManagerTest.java
@@ -21,7 +21,7 @@ import org.apache.dolphinscheduler.common.utils.OSUtils;
 import org.apache.dolphinscheduler.dao.entity.ProcessDefinition;
 import org.apache.dolphinscheduler.dao.entity.ProcessInstance;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
-import org.apache.dolphinscheduler.remote.NettyRemotingServer;
+import org.apache.dolphinscheduler.remote.NettyRemoteServer;
 import org.apache.dolphinscheduler.remote.config.NettyServerConfig;
 import org.apache.dolphinscheduler.remote.utils.Host;
 import org.apache.dolphinscheduler.server.builder.TaskExecutionContextBuilder;
@@ -64,9 +64,9 @@ public class NettyExecutorManagerTest {
     public void testExecute() throws ExecuteException{
         final NettyServerConfig serverConfig = new NettyServerConfig();
         serverConfig.setListenPort(30000);
-        NettyRemotingServer nettyRemotingServer = new NettyRemotingServer(serverConfig);
-        nettyRemotingServer.registerProcessor(org.apache.dolphinscheduler.remote.command.CommandType.TASK_EXECUTE_REQUEST, new TaskExecuteProcessor());
-        nettyRemotingServer.start();
+        NettyRemoteServer nettyRemoteServer = new NettyRemoteServer(serverConfig);
+        nettyRemoteServer.registerProcessor(org.apache.dolphinscheduler.remote.command.CommandType.TASK_EXECUTE_REQUEST, new TaskExecuteProcessor());
+        nettyRemoteServer.start();
         TaskInstance taskInstance = Mockito.mock(TaskInstance.class);
         ProcessDefinition processDefinition = Mockito.mock(ProcessDefinition.class);
         ProcessInstance processInstance = new ProcessInstance();
@@ -81,7 +81,7 @@ public class NettyExecutorManagerTest {
         executionContext.setHost(Host.of(OSUtils.getHost() + ":" + serverConfig.getListenPort()));
         Boolean execute = nettyExecutorManager.execute(executionContext);
         Assert.assertTrue(execute);
-        nettyRemotingServer.close();
+        nettyRemoteServer.close();
     }
 
     @Test(expected = ExecuteException.class)

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/worker/processor/TaskCallbackServiceTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/worker/processor/TaskCallbackServiceTest.java
@@ -18,8 +18,8 @@ package org.apache.dolphinscheduler.server.worker.processor;
 
 import io.netty.channel.Channel;
 import org.apache.dolphinscheduler.common.thread.Stopper;
-import org.apache.dolphinscheduler.remote.NettyRemotingClient;
-import org.apache.dolphinscheduler.remote.NettyRemotingServer;
+import org.apache.dolphinscheduler.remote.NettyRemoteClient;
+import org.apache.dolphinscheduler.remote.NettyRemoteServer;
 import org.apache.dolphinscheduler.remote.command.CommandType;
 import org.apache.dolphinscheduler.remote.command.TaskExecuteAckCommand;
 import org.apache.dolphinscheduler.remote.command.TaskExecuteResponseCommand;
@@ -78,13 +78,13 @@ public class TaskCallbackServiceTest {
     public void testSendAck() throws Exception{
         final NettyServerConfig serverConfig = new NettyServerConfig();
         serverConfig.setListenPort(30000);
-        NettyRemotingServer nettyRemotingServer = new NettyRemotingServer(serverConfig);
-        nettyRemotingServer.registerProcessor(CommandType.TASK_EXECUTE_ACK, taskAckProcessor);
-        nettyRemotingServer.start();
+        NettyRemoteServer nettyRemoteServer = new NettyRemoteServer(serverConfig);
+        nettyRemoteServer.registerProcessor(CommandType.TASK_EXECUTE_ACK, taskAckProcessor);
+        nettyRemoteServer.start();
 
         final NettyClientConfig clientConfig = new NettyClientConfig();
-        NettyRemotingClient nettyRemotingClient = new NettyRemotingClient(clientConfig);
-        Channel channel = nettyRemotingClient.getChannel(Host.of("localhost:30000"));
+        NettyRemoteClient nettyRemoteClient = new NettyRemoteClient(clientConfig);
+        Channel channel = nettyRemoteClient.getChannel(Host.of("localhost:30000"));
         taskCallbackService.addRemoteChannel(1, new NettyRemoteChannel(channel, 1));
         TaskExecuteAckCommand ackCommand = new TaskExecuteAckCommand();
         ackCommand.setTaskInstanceId(1);
@@ -97,8 +97,8 @@ public class TaskCallbackServiceTest {
 
         Thread.sleep(5000);
 
-        nettyRemotingServer.close();
-        nettyRemotingClient.close();
+        nettyRemoteServer.close();
+        nettyRemoteClient.close();
     }
 
     /**
@@ -109,13 +109,13 @@ public class TaskCallbackServiceTest {
     public void testSendResult() throws Exception{
         final NettyServerConfig serverConfig = new NettyServerConfig();
         serverConfig.setListenPort(30000);
-        NettyRemotingServer nettyRemotingServer = new NettyRemotingServer(serverConfig);
-        nettyRemotingServer.registerProcessor(CommandType.TASK_EXECUTE_RESPONSE, taskResponseProcessor);
-        nettyRemotingServer.start();
+        NettyRemoteServer nettyRemoteServer = new NettyRemoteServer(serverConfig);
+        nettyRemoteServer.registerProcessor(CommandType.TASK_EXECUTE_RESPONSE, taskResponseProcessor);
+        nettyRemoteServer.start();
 
         final NettyClientConfig clientConfig = new NettyClientConfig();
-        NettyRemotingClient nettyRemotingClient = new NettyRemotingClient(clientConfig);
-        Channel channel = nettyRemotingClient.getChannel(Host.of("localhost:30000"));
+        NettyRemoteClient nettyRemoteClient = new NettyRemoteClient(clientConfig);
+        Channel channel = nettyRemoteClient.getChannel(Host.of("localhost:30000"));
         taskCallbackService.addRemoteChannel(1, new NettyRemoteChannel(channel, 1));
         TaskExecuteResponseCommand responseCommand  = new TaskExecuteResponseCommand();
         responseCommand.setTaskInstanceId(1);
@@ -129,8 +129,8 @@ public class TaskCallbackServiceTest {
 
         Thread.sleep(5000);
 
-        nettyRemotingServer.close();
-        nettyRemotingClient.close();
+        nettyRemoteServer.close();
+        nettyRemoteClient.close();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -145,20 +145,20 @@ public class TaskCallbackServiceTest {
         masterRegistry.registry();
         final NettyServerConfig serverConfig = new NettyServerConfig();
         serverConfig.setListenPort(30000);
-        NettyRemotingServer nettyRemotingServer = new NettyRemotingServer(serverConfig);
-        nettyRemotingServer.registerProcessor(CommandType.TASK_EXECUTE_ACK, taskAckProcessor);
-        nettyRemotingServer.start();
+        NettyRemoteServer nettyRemoteServer = new NettyRemoteServer(serverConfig);
+        nettyRemoteServer.registerProcessor(CommandType.TASK_EXECUTE_ACK, taskAckProcessor);
+        nettyRemoteServer.start();
 
         final NettyClientConfig clientConfig = new NettyClientConfig();
-        NettyRemotingClient nettyRemotingClient = new NettyRemotingClient(clientConfig);
-        Channel channel = nettyRemotingClient.getChannel(Host.of("localhost:30000"));
+        NettyRemoteClient nettyRemoteClient = new NettyRemoteClient(clientConfig);
+        Channel channel = nettyRemoteClient.getChannel(Host.of("localhost:30000"));
         taskCallbackService.addRemoteChannel(1, new NettyRemoteChannel(channel, 1));
         channel.close();
         TaskExecuteAckCommand ackCommand = new TaskExecuteAckCommand();
         ackCommand.setTaskInstanceId(1);
         ackCommand.setStartTime(new Date());
 
-        nettyRemotingServer.close();
+        nettyRemoteServer.close();
 
         taskCallbackService.sendAck(1, ackCommand.convert2Command());
         try {

--- a/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/log/LogClientService.java
+++ b/dolphinscheduler-service/src/main/java/org/apache/dolphinscheduler/service/log/LogClientService.java
@@ -16,7 +16,7 @@
  */
 package org.apache.dolphinscheduler.service.log;
 
-import org.apache.dolphinscheduler.remote.NettyRemotingClient;
+import org.apache.dolphinscheduler.remote.NettyRemoteClient;
 import org.apache.dolphinscheduler.remote.command.Command;
 import org.apache.dolphinscheduler.remote.command.log.*;
 import org.apache.dolphinscheduler.remote.config.NettyClientConfig;
@@ -35,7 +35,7 @@ public class LogClientService {
 
     private final NettyClientConfig clientConfig;
 
-    private final NettyRemotingClient client;
+    private final NettyRemoteClient client;
 
     /**
      *  request time out
@@ -48,7 +48,7 @@ public class LogClientService {
     public LogClientService() {
         this.clientConfig = new NettyClientConfig();
         this.clientConfig.setWorkerThreads(4);
-        this.client = new NettyRemotingClient(clientConfig);
+        this.client = new NettyRemoteClient(clientConfig);
     }
 
     /**


### PR DESCRIPTION
## What is the purpose of the pull request

rename 'Remoting' to 'Remote' to make it standard and reasonable

## Brief change log

rename 'Remoting' to 'Remote' to make it standard and reasonable, for example 
NettyRemotingServer-->NettyRemoteServer
NettyRemotingClient-->NettyRemoteClient