### PR TITLE
[bugfix] fix alert.json and metainfo.xml bugs 

### DIFF
--- a/ambari_plugin/common-services/DOLPHIN/1.3.0/alerts.json
+++ b/ambari_plugin/common-services/DOLPHIN/1.3.0/alerts.json
@@ -28,6 +28,33 @@
         }
       }
     ],
+    "DOLPHIN_LOGGER": [
+      {
+        "name": "dolphin_logger_port_check",
+        "label": "dolphin_logger_port_check",
+        "description": "dolphin_logger_port_check.",
+        "interval": 10,
+        "scope": "ANY",
+        "source": {
+          "type": "PORT",
+          "uri": "{{dolphin-common/loggerserver.rpc.port}}",
+          "default_port": 50051,
+          "reporting": {
+            "ok": {
+              "text": "TCP OK - {0:.3f}s response on port {1}"
+            },
+            "warning": {
+              "text": "TCP OK - {0:.3f}s response on port {1}",
+              "value": 1.5
+            },
+            "critical": {
+              "text": "Connection failed: {0} to {1}:{2}",
+              "value": 5.0
+            }
+          }
+        }
+      }
+    ],
     "DOLPHIN_MASTER": [
       {
         "name": "DOLPHIN_MASTER_CHECK",
@@ -120,39 +147,6 @@
               "name": "alertName",
               "display_name": "alertName",
               "value": "DOLPHIN_ALERT",
-              "type": "STRING",
-              "description": "alert name"
-            }
-          ]
-        }
-      }
-    ],
-    "DOLPHIN_ALERT": [
-      {
-        "name": "DOLPHIN_DOLPHIN_LOGGER_CHECK",
-        "label": "check dolphin scheduler alert status",
-        "description": "",
-        "interval":10,
-        "scope": "HOST",
-        "enabled": true,
-        "source": {
-          "type": "SCRIPT",
-          "path": "DOLPHIN/1.3.0/package/alerts/alert_dolphin_scheduler_status.py",
-          "parameters": [
-
-            {
-              "name": "connection.timeout",
-              "display_name": "Connection Timeout",
-              "value": 5.0,
-              "type": "NUMERIC",
-              "description": "The maximum time before this alert is considered to be CRITICAL",
-              "units": "seconds",
-              "threshold": "CRITICAL"
-            },
-            {
-              "name": "alertName",
-              "display_name": "alertName",
-              "value": "DOLPHIN_LOGGER",
               "type": "STRING",
               "description": "alert name"
             }

--- a/ambari_plugin/common-services/DOLPHIN/1.3.0/metainfo.xml
+++ b/ambari_plugin/common-services/DOLPHIN/1.3.0/metainfo.xml
@@ -103,7 +103,7 @@
                     <osFamily>any</osFamily>
                     <packages>
                         <package>
-                            <name>apache-dolphinscheduler-incubating-1.3.0*</name>
+                            <name>apache-dolphinscheduler-incubating*</name>
                         </package>
                     </packages>
                 </osSpecific>


### PR DESCRIPTION
1. fix alert.json includes repeated tag 'DOLPHIN_ALERT' 2. metainfo.xml The version number of the RPM package is no longer specified in the metainfo.xml