### PR TITLE
fix single yarn get application status failed

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HadoopUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HadoopUtils.java
@@ -206,7 +206,6 @@ public class HadoopUtils implements Closeable {
             //yarn conf error
             yarnEnabled = false;
             logger.error("Yarn conf error, Please check the yarn conf in hadoop.properties");
-            throw new RuntimeException("Yarn conf error, Please check the yarn conf in hadoop.properties");
         }
 
         return String.format(appUrl, applicationId);

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HadoopUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HadoopUtils.java
@@ -193,19 +193,20 @@ public class HadoopUtils implements Closeable {
          *  if rmHaIds not empty: resourcemanager HA enabled
          */
         String appUrl = "";
-        //not use resourcemanager
-        if (rmHaIds.contains(Constants.YARN_RESOURCEMANAGER_HA_XX)) {
-
-            yarnEnabled = false;
-            logger.warn("should not step here");
-        } else if (!StringUtils.isEmpty(rmHaIds)) {
-            //resourcemanager HA enabled
+        //resource manager HA
+        if (StringUtils.isNotEmpty(rmHaIds) && !rmHaIds.contains(Constants.YARN_RESOURCEMANAGER_HA_XX)) {
             appUrl = getAppAddress(appAddress, rmHaIds);
             yarnEnabled = true;
             logger.info("application url : {}", appUrl);
-        } else {
-            //single resourcemanager enabled
+        } else if (StringUtils.isNotEmpty(appAddress) && !appAddress.contains("ark1")){
+            //single resource manager
             yarnEnabled = true;
+            appUrl = appAddress;
+        } else {
+            //yarn conf error
+            yarnEnabled = false;
+            logger.error("Yarn conf error, Please check the yarn conf in hadoop.properties");
+            throw new RuntimeException("Yarn conf error, Please check the yarn conf in hadoop.properties");
         }
 
         return String.format(appUrl, applicationId);

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/HadoopUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/HadoopUtilsTest.java
@@ -186,8 +186,11 @@ public class HadoopUtilsTest {
 
     @Test
     public void getApplicationUrl(){
-        String application_1516778421218_0042 = hadoopUtils.getApplicationUrl("application_1529051418016_0167");
-        logger.info(application_1516778421218_0042);
+        try {
+            String application_1516778421218_0042 = hadoopUtils.getApplicationUrl("application_1529051418016_0167");
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+        }
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the pull request

*fix single yarn get application status failed*
deploy dolphin scheduler in single yarn hadoop cluster, 
exec a yarn job will lead npe when get the yarn app status 

## Brief change log

  - *Modify HadoopUtils*

## Verify this pull request

This pull request is already covered by existing tests, such as:
*dolphinscheduler/common/utils/HadoopUtilsTest.java*

