### PR TITLE
[Bug-3187]close Heartbeat thread pool when MasterRegistry unRegistry

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/registry/MasterRegistry.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/registry/MasterRegistry.java
@@ -110,14 +110,7 @@ public class MasterRegistry {
     public void unRegistry() {
         String address = getLocalAddress();
         String localNodePath = getMasterPath();
-        heartBeatExecutor.shutdown();
-        try {
-            if (heartBeatExecutor.awaitTermination(masterConfig.getMasterHeartbeatInterval(), TimeUnit.SECONDS)) {
-                logger.warn("The heartbeat executor does not shutdown");
-            }
-        } catch (InterruptedException e) {
-            logger.warn("The heartbeat executor is interrupted");
-        }
+        heartBeatExecutor.shutdownNow();
         zookeeperRegistryCenter.getZookeeperCachedOperator().remove(localNodePath);
         logger.info("master node : {} unRegistry to ZK.", address);
     }
@@ -142,7 +135,4 @@ public class MasterRegistry {
 
     }
 
-    public ScheduledExecutorService getHeartBeatExecutor() {
-        return heartBeatExecutor;
-    }
 }

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/registry/MasterRegistryTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/registry/MasterRegistryTest.java
@@ -67,7 +67,6 @@ public class MasterRegistryTest {
         masterRegistry.unRegistry();
         String masterPath = zookeeperRegistryCenter.getMasterPath();
         List<String> childrenKeys = zookeeperRegistryCenter.getZookeeperCachedOperator().getChildrenKeys(masterPath);
-        Assert.assertTrue(masterRegistry.getHeartBeatExecutor().isShutdown());
         Assert.assertTrue(childrenKeys.isEmpty());
     }
 }

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/registry/MasterRegistryTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/registry/MasterRegistryTest.java
@@ -67,6 +67,7 @@ public class MasterRegistryTest {
         masterRegistry.unRegistry();
         String masterPath = zookeeperRegistryCenter.getMasterPath();
         List<String> childrenKeys = zookeeperRegistryCenter.getZookeeperCachedOperator().getChildrenKeys(masterPath);
+        Assert.assertTrue(masterRegistry.getHeartBeatExecutor().isShutdown());
         Assert.assertTrue(childrenKeys.isEmpty());
     }
 }


### PR DESCRIPTION
fix #3187 
## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds checkstyle plugin.)*

## Brief change log

Close Heartbeat thread pool when MasterRegistry unRegistry.
Add unit test

## Verify this pull request

*(Please pick either of the following options)*

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.*
