### PR TITLE
[Bug 2923] Hive JDBC connection parameter ignored

### DIFF
--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/datasource/HiveDataSource.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/datasource/HiveDataSource.java
@@ -81,7 +81,15 @@ public class HiveDataSource extends BaseDataSource {
       }
     }
 
-    return sessionVarListSb.toString().substring(0, sessionVarListSb.length() - 1) +
-        hiveConfListSb.toString().substring(0, hiveConfListSb.length() - 1);
+    // remove the last ";"
+    if(sessionVarListSb.length() > 0){
+      sessionVarListSb.deleteCharAt(sessionVarListSb.length() - 1 );
+    }
+
+    if(hiveConfListSb.length() > 0){
+      hiveConfListSb.deleteCharAt(hiveConfListSb.length() - 1);
+    }
+
+    return sessionVarListSb.toString() + hiveConfListSb.toString();
   }
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/datasource/HiveDataSource.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/datasource/HiveDataSource.java
@@ -16,8 +16,14 @@
  */
 package org.apache.dolphinscheduler.dao.datasource;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.commons.lang.text.StrBuilder;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.DbType;
+import org.apache.dolphinscheduler.common.utils.StringUtils;
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 
 /**
  * data source of hive
@@ -39,5 +45,43 @@ public class HiveDataSource extends BaseDataSource {
   @Override
   public DbType dbTypeSelector() {
     return DbType.HIVE;
+  }
+
+  /**
+   * build hive jdbc params,append : ?hive_conf_list
+   *
+   * hive jdbc url template:
+   *
+   * jdbc:hive2://<host1>:<port1>,<host2>:<port2>/dbName;initFile=<file>;sess_var_list?hive_conf_list#hive_var_list
+   *
+   * @param otherParams otherParams
+   * @return filter otherParams
+   */
+  @Override
+  protected String filterOther(String otherParams) {
+    if(StringUtils.isBlank(otherParams)){
+      return "";
+    }
+
+    StrBuilder hiveConfListSb = new StrBuilder();
+    hiveConfListSb.append("?");
+    StrBuilder sessionVarListSb = new StrBuilder();
+
+    String[] otherArray = otherParams.split(";", -1);
+
+    // get the default hive conf var name
+    Set<String> hiveConfSet = Stream.of(ConfVars.values()).map(confVars -> confVars.varname)
+        .collect(Collectors.toSet());
+
+    for (String conf : otherArray) {
+      if (hiveConfSet.contains(conf.split("=")[0])) {
+        hiveConfListSb.append(conf).append(";");
+      } else {
+        sessionVarListSb.append(conf).append(";");
+      }
+    }
+
+    return sessionVarListSb.toString().substring(0, sessionVarListSb.length() - 1) +
+        hiveConfListSb.toString().substring(0, hiveConfListSb.length() - 1);
   }
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/datasource/HiveDataSource.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/datasource/HiveDataSource.java
@@ -92,4 +92,5 @@ public class HiveDataSource extends BaseDataSource {
 
     return sessionVarListSb.toString() + hiveConfListSb.toString();
   }
+  
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/datasource/HiveDataSource.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/datasource/HiveDataSource.java
@@ -14,15 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.dolphinscheduler.dao.datasource;
 
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import org.apache.commons.lang.text.StrBuilder;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.DbType;
 import org.apache.dolphinscheduler.common.utils.StringUtils;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 
 /**
@@ -59,13 +59,13 @@ public class HiveDataSource extends BaseDataSource {
    */
   @Override
   protected String filterOther(String otherParams) {
-    if(StringUtils.isBlank(otherParams)){
+    if (StringUtils.isBlank(otherParams)) {
       return "";
     }
 
-    StrBuilder hiveConfListSb = new StrBuilder();
+    StringBuilder hiveConfListSb = new StringBuilder();
     hiveConfListSb.append("?");
-    StrBuilder sessionVarListSb = new StrBuilder();
+    StringBuilder sessionVarListSb = new StringBuilder();
 
     String[] otherArray = otherParams.split(";", -1);
 
@@ -82,11 +82,11 @@ public class HiveDataSource extends BaseDataSource {
     }
 
     // remove the last ";"
-    if(sessionVarListSb.length() > 0){
-      sessionVarListSb.deleteCharAt(sessionVarListSb.length() - 1 );
+    if (sessionVarListSb.length() > 0) {
+      sessionVarListSb.deleteCharAt(sessionVarListSb.length() - 1);
     }
 
-    if(hiveConfListSb.length() > 0){
+    if (hiveConfListSb.length() > 0) {
       hiveConfListSb.deleteCharAt(hiveConfListSb.length() - 1);
     }
 

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/datasource/HiveDataSourceTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/datasource/HiveDataSourceTest.java
@@ -20,6 +20,10 @@ public class HiveDataSourceTest {
     other = hiveDataSource.filterOther("");
     Assert.assertEquals("", other);
 
+    // only contain hive_site_conf
+    other = hiveDataSource.filterOther("hive.mapred.mode=strict");
+    Assert.assertEquals("?hive.mapred.mode=strict", other);
+
     // contain hive_site_conf at the first
     other = hiveDataSource.filterOther("hive.mapred.mode=strict;charset=UTF-8");
     Assert.assertEquals("charset=UTF-8?hive.mapred.mode=strict", other);
@@ -51,6 +55,12 @@ public class HiveDataSourceTest {
 
     Assert.assertEquals(
         "jdbc:hive2://127.0.0.1:10000/test;charset=UTF-8?hive.mapred.mode=strict;hive.server2.thrift.http.path=hs2",
+        hiveDataSource.getJdbcUrl());
+
+    hiveDataSource.setOther("hive.mapred.mode=strict;hive.server2.thrift.http.path=hs2");
+
+    Assert.assertEquals(
+        "jdbc:hive2://127.0.0.1:10000/test;?hive.mapred.mode=strict;hive.server2.thrift.http.path=hs2",
         hiveDataSource.getJdbcUrl());
 
   }

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/datasource/HiveDataSourceTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/datasource/HiveDataSourceTest.java
@@ -1,0 +1,58 @@
+package org.apache.dolphinscheduler.dao.datasource;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * test data source of hive
+ */
+public class HiveDataSourceTest {
+
+  @Test
+  public void testfilterOther() {
+    BaseDataSource hiveDataSource = new HiveDataSource();
+
+    // not contain hive_site_conf
+    String other = hiveDataSource.filterOther("charset=UTF-8");
+    Assert.assertEquals("charset=UTF-8", other);
+
+    // not contain
+    other = hiveDataSource.filterOther("");
+    Assert.assertEquals("", other);
+
+    // contain hive_site_conf at the first
+    other = hiveDataSource.filterOther("hive.mapred.mode=strict;charset=UTF-8");
+    Assert.assertEquals("charset=UTF-8?hive.mapred.mode=strict", other);
+
+    // contain hive_site_conf in the middle
+    other = hiveDataSource.filterOther("charset=UTF-8;hive.mapred.mode=strict;foo=bar");
+    Assert.assertEquals("charset=UTF-8;foo=bar?hive.mapred.mode=strict", other);
+
+    // contain hive_site_conf at the end
+    other = hiveDataSource.filterOther("charset=UTF-8;foo=bar;hive.mapred.mode=strict");
+    Assert.assertEquals("charset=UTF-8;foo=bar?hive.mapred.mode=strict", other);
+
+    // contain multi hive_site_conf
+    other = hiveDataSource.filterOther("charset=UTF-8;foo=bar;hive.mapred.mode=strict;hive.exec.parallel=true");
+    Assert.assertEquals("charset=UTF-8;foo=bar?hive.mapred.mode=strict;hive.exec.parallel=true", other);
+  }
+
+  @Test
+  public void testGetHiveJdbcUrlOther() {
+
+    BaseDataSource hiveDataSource = new HiveDataSource();
+    hiveDataSource.setAddress("jdbc:hive2://127.0.0.1:10000");
+    hiveDataSource.setDatabase("test");
+    hiveDataSource.setPassword("123456");
+    hiveDataSource.setUser("test");
+    Assert.assertEquals("jdbc:hive2://127.0.0.1:10000/test", hiveDataSource.getJdbcUrl());
+
+    hiveDataSource.setOther("charset=UTF-8;hive.mapred.mode=strict;hive.server2.thrift.http.path=hs2");
+
+    Assert.assertEquals(
+        "jdbc:hive2://127.0.0.1:10000/test;charset=UTF-8?hive.mapred.mode=strict;hive.server2.thrift.http.path=hs2",
+        hiveDataSource.getJdbcUrl());
+
+  }
+
+}

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/datasource/HiveDataSourceTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/datasource/HiveDataSourceTest.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.dolphinscheduler.dao.datasource;
 
 import org.junit.Assert;

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/datasource/HiveDataSourceTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/datasource/HiveDataSourceTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dolphinscheduler.dao.datasource;
 
 import org.junit.Assert;

--- a/pom.xml
+++ b/pom.xml
@@ -852,6 +852,7 @@
                         <include>**/dao/utils/DagHelperTest.java</include>
                         <include>**/dao/AlertDaoTest.java</include>
                         <include>**/dao/datasource/OracleDataSourceTest.java</include>
+                        <include>**/dao/datasource/HiveDataSourceTest.java</include>
                         <include>**/dao/upgrade/ProcessDefinitionDaoTest.java</include>
                         <include>**/dao/upgrade/WokrerGrouopDaoTest.java</include>
                         <include>**/dao/upgrade/UpgradeDaoTest.java</include>


### PR DESCRIPTION
fix the bug #2923 
## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

## What is the purpose of the pull request

*This pull request fix the bug #2923*

Corrected the connection string of hive jdbc link string. If the parameter in the link string is the configuration parameter in hive-default.xml, add it before the parameter ?.
<br>
> see the hive Connection URLs - Connection URL Format
[HiveServer2Clients-ConnectionURLs](https://cwiki.apache.org/confluence/display/Hive/HiveServer2+Clients#HiveServer2Clients-ConnectionURLs)

```
Connection URLs
Connection URL Format
The HiveServer2 URL is a string with the following syntax:

jdbc:hive2://<host1>:<port1>,<host2>:<port2>/dbName;initFile=<file>;sess_var_list?hive_conf_list#hive_var_list

where

<host1>:<port1>,<host2>:<port2> is a server instance or a comma separated list of server instances to connect to (if dynamic service discovery is enabled). If empty, the embedded server will be used.
dbName is the name of the initial database.
<file> is the path of init script file (Hive 2.2.0 and later). This script file is written with SQL statements which will be executed automatically after connection. This option can be empty. 
sess_var_list is a semicolon separated list of key=value pairs of session variables (e.g., user=foo;password=bar).
hive_conf_list is a semicolon separated list of key=value pairs of Hive configuration variables for this session
hive_var_list is a semicolon separated list of key=value pairs of Hive variables for this session.
Special characters in sess_var_list, hive_conf_list, hive_var_list parameter values should be encoded with URL encoding if needed.
```

## Brief change log

  -  **Ｍodify　the  function of org.apache.dolphinscheduler.dao.datasource.HiveDataSource#filterOther** 
  -  **Add HiveDataSourceTest.java for the test case of the  HiveDataSource#filterOther**

## Verify this pull request


This change added tests and can be verified as follows:

  - *Added HiveDataSourceTest to verify the change.*

