### PR TITLE
[BUG#2359][Alert] Mail Chinese name is too long garbled

### DIFF
--- a/dolphinscheduler-alert/src/main/java/org/apache/dolphinscheduler/alert/utils/MailUtils.java
+++ b/dolphinscheduler-alert/src/main/java/org/apache/dolphinscheduler/alert/utils/MailUtils.java
@@ -65,6 +65,7 @@ public class MailUtils {
 
     public static final AlertTemplate alertTemplate = AlertTemplateFactory.getMessageTemplate();
 
+    //Solve the problem of messy Chinese name in excel attachment
     static {
         System.setProperty("mail.mime.splitlongparameters","false");
     }

--- a/dolphinscheduler-alert/src/main/java/org/apache/dolphinscheduler/alert/utils/MailUtils.java
+++ b/dolphinscheduler-alert/src/main/java/org/apache/dolphinscheduler/alert/utils/MailUtils.java
@@ -70,7 +70,6 @@ public class MailUtils {
         System.setProperty("mail.mime.splitlongparameters","false");
     }
 
-
     /**
      * send mail to receivers
      * @param receivers the receiver list

--- a/dolphinscheduler-alert/src/main/java/org/apache/dolphinscheduler/alert/utils/MailUtils.java
+++ b/dolphinscheduler-alert/src/main/java/org/apache/dolphinscheduler/alert/utils/MailUtils.java
@@ -65,6 +65,10 @@ public class MailUtils {
 
     public static final AlertTemplate alertTemplate = AlertTemplateFactory.getMessageTemplate();
 
+    static {
+        System.setProperty("mail.mime.splitlongparameters","false");
+    }
+
 
     /**
      * send mail to receivers

--- a/dolphinscheduler-alert/src/main/java/org/apache/dolphinscheduler/alert/utils/MailUtils.java
+++ b/dolphinscheduler-alert/src/main/java/org/apache/dolphinscheduler/alert/utils/MailUtils.java
@@ -345,4 +345,5 @@ public class MailUtils {
         retMap.put(Constants.MESSAGE, "Send email to {" + String.join(",", receivers) + "} failed，" + e.toString());
     }
 
+    
 }


### PR DESCRIPTION

## Brief change log

  - *Set the system property of "mail.mime.splitlongparameters" is false in the class "org.apache.dolphinscheduler.alert.utils.MailUtils"*

## Verify this pull request

This pull request is already covered by existing tests.
  - *Manually verified the change by testing locally.*

local test method : org.apache.dolphinscheduler.alert.utils.MailUtilsTest#testSendMails
situation one: Chinese 100.    result: success
![image](https://user-images.githubusercontent.com/61645312/87265846-609b2280-c4f6-11ea-919a-7a35442d2113.png)

situation two: Chinese 100 + English 100.   result: success
![image](https://user-images.githubusercontent.com/61645312/87266097-fc2c9300-c4f6-11ea-8443-3b3e8400a037.png)

other situation: Whether I set this property or not, and whether the name contains Chinese or not.when the length of  attachment is too long, the mail will send failed. ( i have been test the situation that the length is 500, but i'm not sure the max length,because the exception is thrown by a native method) 

