### PR TITLE
[Fix][server&api&worker] Fix add ZOOKEEPER_ROOT env in k8s deploy

### DIFF
--- a/docker/kubernetes/dolphinscheduler/templates/deployment-dolphinscheduler-api.yaml
+++ b/docker/kubernetes/dolphinscheduler/templates/deployment-dolphinscheduler-api.yaml
@@ -162,6 +162,12 @@ spec:
               {{- else }}
               value: {{ .Values.externalZookeeper.zookeeperQuorum }}
               {{- end }}
+            - name: ZOOKEEPER_ROOT
+              {{- if .Values.zookeeper.enabled }}
+              value: "/dolphinscheduler"
+              {{- else }}
+              value: {{ .Values.externalZookeeper.zookeeperRoot }}
+              {{- end }}
             - name: RESOURCE_STORAGE_TYPE
               valueFrom:
                 configMapKeyRef:

--- a/docker/kubernetes/dolphinscheduler/templates/statefulset-dolphinscheduler-master.yaml
+++ b/docker/kubernetes/dolphinscheduler/templates/statefulset-dolphinscheduler-master.yaml
@@ -228,6 +228,12 @@ spec:
               {{- else }}
               value: {{ .Values.externalZookeeper.zookeeperQuorum }}
               {{- end }}
+            - name: ZOOKEEPER_ROOT
+              {{- if .Values.zookeeper.enabled }}
+              value: "/dolphinscheduler"
+              {{- else }}
+              value: {{ .Values.externalZookeeper.zookeeperRoot }}
+              {{- end }}
             - name: RESOURCE_STORAGE_TYPE
               valueFrom:
                 configMapKeyRef:

--- a/docker/kubernetes/dolphinscheduler/templates/statefulset-dolphinscheduler-worker.yaml
+++ b/docker/kubernetes/dolphinscheduler/templates/statefulset-dolphinscheduler-worker.yaml
@@ -225,6 +225,12 @@ spec:
               {{- else }}
               value: {{ .Values.externalZookeeper.zookeeperQuorum }}
               {{- end }}
+            - name: ZOOKEEPER_ROOT
+              {{- if .Values.zookeeper.enabled }}
+              value: "/dolphinscheduler"
+              {{- else }}
+              value: {{ .Values.externalZookeeper.zookeeperRoot }}
+              {{- end }}
             - name: RESOURCE_STORAGE_TYPE
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

## What is the purpose of the pull request

add ZOOKEEPER_ROOT env in k8s deploy

## Brief change log

- modified:   docker/kubernetes/dolphinscheduler/templates/deployment-dolphinscheduler-api.yaml
- modified:   docker/kubernetes/dolphinscheduler/templates/statefulset-dolphinscheduler-master.yaml
- modified:   docker/kubernetes/dolphinscheduler/templates/statefulset-dolphinscheduler-worker.yaml

## Verify this pull request

This pull request is code cleanup without any test coverage.

