### PR TITLE
[FIX_BUG]fix many test errors

### DIFF
--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/MasterExecThreadTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/MasterExecThreadTest.java
@@ -84,7 +84,7 @@ public class MasterExecThreadTest {
         Mockito.when(processInstance.getScheduleTime()).thenReturn(DateUtils.stringToDate("2020-01-01 00:00:00"));
         Map<String, String> cmdParam = new HashMap<>();
         cmdParam.put(CMDPARAM_COMPLEMENT_DATA_START_DATE, "2020-01-01 00:00:00");
-        cmdParam.put(CMDPARAM_COMPLEMENT_DATA_END_DATE, "2020-01-05 23:00:00");
+        cmdParam.put(CMDPARAM_COMPLEMENT_DATA_END_DATE, "2020-01-31 23:00:00");
         Mockito.when(processInstance.getCommandParam()).thenReturn(JSONUtils.toJsonString(cmdParam));
         ProcessDefinition processDefinition = new ProcessDefinition();
         processDefinition.setGlobalParamMap(Collections.EMPTY_MAP);
@@ -115,7 +115,7 @@ public class MasterExecThreadTest {
             method.setAccessible(true);
             method.invoke(masterExecThread);
             // one create save, and 1-30 for next save, and last day 31 no save
-            verify(processService, times(5)).saveProcessInstance(processInstance);
+            verify(processService, times(31)).saveProcessInstance(processInstance);
         }catch (Exception e){
             e.printStackTrace();
             Assert.assertTrue(false);
@@ -134,7 +134,7 @@ public class MasterExecThreadTest {
             method.setAccessible(true);
             method.invoke(masterExecThread);
             // one create save, and 15(1 to 31 step 2) for next save, and last day 31 no save
-            verify(processService, times(2)).saveProcessInstance(processInstance);
+            verify(processService, times(15)).saveProcessInstance(processInstance);
         }catch (Exception e){
             Assert.assertTrue(false);
         }

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/MasterExecThreadTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/MasterExecThreadTest.java
@@ -84,7 +84,7 @@ public class MasterExecThreadTest {
         Mockito.when(processInstance.getScheduleTime()).thenReturn(DateUtils.stringToDate("2020-01-01 00:00:00"));
         Map<String, String> cmdParam = new HashMap<>();
         cmdParam.put(CMDPARAM_COMPLEMENT_DATA_START_DATE, "2020-01-01 00:00:00");
-        cmdParam.put(CMDPARAM_COMPLEMENT_DATA_END_DATE, "2020-01-31 23:00:00");
+        cmdParam.put(CMDPARAM_COMPLEMENT_DATA_END_DATE, "2020-01-05 23:00:00");
         Mockito.when(processInstance.getCommandParam()).thenReturn(JSONUtils.toJsonString(cmdParam));
         ProcessDefinition processDefinition = new ProcessDefinition();
         processDefinition.setGlobalParamMap(Collections.EMPTY_MAP);
@@ -115,7 +115,7 @@ public class MasterExecThreadTest {
             method.setAccessible(true);
             method.invoke(masterExecThread);
             // one create save, and 1-30 for next save, and last day 31 no save
-            verify(processService, times(31)).saveProcessInstance(processInstance);
+            verify(processService, times(5)).saveProcessInstance(processInstance);
         }catch (Exception e){
             e.printStackTrace();
             Assert.assertTrue(false);
@@ -134,7 +134,7 @@ public class MasterExecThreadTest {
             method.setAccessible(true);
             method.invoke(masterExecThread);
             // one create save, and 15(1 to 31 step 2) for next save, and last day 31 no save
-            verify(processService, times(15)).saveProcessInstance(processInstance);
+            verify(processService, times(2)).saveProcessInstance(processInstance);
         }catch (Exception e){
             Assert.assertTrue(false);
         }

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/consumer/TaskPriorityQueueConsumerTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/consumer/TaskPriorityQueueConsumerTest.java
@@ -32,6 +32,7 @@ import org.apache.dolphinscheduler.server.zk.SpringZKServer;
 import org.apache.dolphinscheduler.service.bean.SpringApplicationContext;
 import org.apache.dolphinscheduler.service.process.ProcessService;
 import org.apache.dolphinscheduler.service.queue.TaskPriorityQueue;
+import org.apache.dolphinscheduler.service.zk.CuratorZookeeperClient;
 import org.apache.dolphinscheduler.service.zk.ZookeeperCachedOperator;
 import org.apache.dolphinscheduler.service.zk.ZookeeperConfig;
 import org.junit.Before;
@@ -46,7 +47,7 @@ import java.util.Date;
 
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes={DependencyConfig.class, SpringApplicationContext.class, SpringZKServer.class,
+@ContextConfiguration(classes={DependencyConfig.class, SpringApplicationContext.class, SpringZKServer.class, CuratorZookeeperClient.class,
         NettyExecutorManager.class, ExecutorDispatcher.class, ZookeeperRegistryCenter.class, TaskPriorityQueueConsumer.class,
         ZookeeperNodeManager.class, ZookeeperCachedOperator.class, ZookeeperConfig.class, MasterConfig.class})
 public class TaskPriorityQueueConsumerTest {


### PR DESCRIPTION
add CuratorZookeeperClient springContextConfig


## What is the purpose of the pull request

1:add CuratorZookeeperClient springContextConfig

When I started the TaskPriorityQueueConsumerTest class, he encountered the following exception

Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name'nettyExecutorManager': Unsatisfied dependency expressed through field'zookeeperNodeManager'; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name ' zookeeperNodeManager': Unsatisfied dependency expressed through field'registryCenter'; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name'zookeeperRegistryCenter': Unsatisfied dependency expressed through field'zookeeperCachedOperator'; nested exception is org.framework. beans.factory.UnsatisfiedDependencyException: Error creating bean with name'zookeeperCachedOperator': Unsatisfied dependency expressed through field'zookeeperClient'; nested exception is org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type'org.apache.dolphinscheduler.service .zk.CuratorZookeepe rClient' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {@org.springframework.beans.factory.annotation.Autowired(required=true)}
2:reduce processService the number of executions
## Verify this pull request

This pull request is code cleanup without any test coverage.

