### PR TITLE
[Feature][server]support one worker can belongs different worker group when execute install script

### DIFF
--- a/dolphinscheduler-server/src/main/resources/worker.properties
+++ b/dolphinscheduler-server/src/main/resources/worker.properties
@@ -30,5 +30,5 @@
 # worker listener port
 #worker.listen.port: 1234
 
-# default worker group
-#worker.groups=default
+# default worker group,if this worker belongs different groups,you can config the following like that `worker.groups=default,test`
+worker.groups=default

--- a/script/scp-hosts.sh
+++ b/script/scp-hosts.sh
@@ -34,7 +34,12 @@ do
   echo $workerGroup;
   worker=`echo $workerGroup|awk -F':' '{print $1}'`
   groupName=`echo $workerGroup|awk -F':' '{print $2}'`
-  workersGroupMap+=([$worker]=$groupName)
+  if [ -z ${workersGroupMap[$worker]} ];then
+      workersGroupMap+=([$worker]=$groupName)
+  else
+      finalGroupName="${workersGroupMap[$worker]},$groupName"
+      workersGroupMap[$worker]=$finalGroupName
+  fi
 done
 
 
@@ -53,7 +58,7 @@ do
   do
     # if worker in workersGroupMap
     if [[ "${workersGroupMap[${host}]}" ]] && [[ "${dsDir}" == "conf" ]]; then
-      sed -i ${txt} "s#worker.group.*#worker.group=${workersGroupMap[${host}]}#g" ${dsDir}/worker.properties
+      sed -i ${txt} "s#worker.groups.*#worker.groups=${workersGroupMap[${host}]}#g" ${dsDir}/worker.properties
     fi
 
     echo "start to scp $dsDir to $host/$installPath"


### PR DESCRIPTION
## What is the purpose of the pull request

*when execute install script*

## Brief change log

*when execute install script*

## Verify this pull request

*modfy config/install_config.conf*
workers="ds1:default,ds1:test,ds2:default"
The worekr ds1 will belongs default and test workergoups.