### PR TITLE
[fix-bug #3397]cancel spark task version check

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/task/spark/SparkParameters.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/task/spark/SparkParameters.java
@@ -216,7 +216,7 @@ public class SparkParameters extends AbstractParameters {
 
   @Override
   public boolean checkParameters() {
-    return mainJar != null && programType != null && sparkVersion != null;
+    return mainJar != null && programType != null;
   }
 
   @Override


### PR DESCRIPTION
## What is the purpose of the pull request

*#3397 cancel spark task version check*

## Brief change log

  - *cancel spark task version check*

  - *when there is no sparkversion field in process denifiton json, the submit of spark task is used by default to submit SPARK2_HOME*