### PR TITLE
resolve curator-client dependency confliction 

### DIFF
--- a/dolphinscheduler-api/pom.xml
+++ b/dolphinscheduler-api/pom.xml
@@ -153,8 +153,8 @@
           <artifactId>servlet-api</artifactId>
         </exclusion>
         <exclusion>
-          <artifactId>curator-client</artifactId>
           <groupId>org.apache.curator</groupId>
+          <artifactId>curator-client</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/dolphinscheduler-api/pom.xml
+++ b/dolphinscheduler-api/pom.xml
@@ -152,6 +152,10 @@
           <groupId>javax.servlet</groupId>
           <artifactId>servlet-api</artifactId>
         </exclusion>
+        <exclusion>
+          <artifactId>curator-client</artifactId>
+          <groupId>org.apache.curator</groupId>
+        </exclusion>
       </exclusions>
     </dependency>
 


### PR DESCRIPTION
## What is the purpose of the pull request

the ds use curator-client:4.3.0 dependency by curator-frameworke,
but hadoop-common use  curator-client:2.7.1,
so make the ClassNotFoundException
```
Caused by: java.lang.ClassNotFoundException: org.apache.curator.connection.StandardConnectionHandlingPolicy
```
exclude curator-client in hadoop-common to resolve this
