### PR TITLE
[bug-3480][server]fix ds muti-level directory in zk, which lead to fail to assign work

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/registry/ZookeeperNodeManager.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/registry/ZookeeperNodeManager.java
@@ -155,10 +155,10 @@ public class ZookeeperNodeManager implements InitializingBean {
 
         private String parseGroup(String path){
             String[] parts = path.split("\\/");
-            if(parts.length != 6){
+            if(parts.length < 6){
                 throw new IllegalArgumentException(String.format("worker group path : %s is not valid, ignore", path));
             }
-            String group = parts[4];
+            String group = parts[parts.length - 2];
             return group;
         }
     }


### PR DESCRIPTION
## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

## What is the purpose of the pull request

*fix issue: #3480*

## Brief change log

*ds muti-level directory in zk, which lead to fail to assign work. for example set zookeeper.dolphinscheduler.root=/path/to/dolphinscheduler*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is code cleanup without any test coverage.
