### PR TITLE
[Improvement][code style] Add sign next line automatic assigner

### DIFF
--- a/style/intellij-java-code-style.xml
+++ b/style/intellij-java-code-style.xml
@@ -95,4 +95,7 @@
     <option name="JD_KEEP_EMPTY_EXCEPTION" value="false" />
     <option name="JD_KEEP_EMPTY_RETURN" value="false" />
   </JavaCodeStyleSettings>
+  <codeStyleSettings language="JAVA">
+    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+  </codeStyleSettings>
 </code_scheme>


### PR DESCRIPTION
## What is the purpose of the pull request

*Add sign next line automatic assigner for code style*

*For example:*

It can generate string like this one, it can match the rules of `checkstyle`
```java
String json = "{\"a\":"
 +  \"b\"}";
```
not like this one

```java
String json = "{\"a\":"+ 
 \"b\"}";
```