### PR TITLE
[Fix-3536][api]If user didn't have tenant,create resource directory will NPE

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ResourcesService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ResourcesService.java
@@ -121,13 +121,6 @@ public class ResourcesService extends BaseService {
             }
         }
 
-
-        if (checkResourceExists(fullName, 0, type.ordinal())) {
-            logger.error("resource directory {} has exist, can't recreate", fullName);
-            putMsg(result, Status.RESOURCE_EXIST);
-            return result;
-        }
-
         Date now = new Date();
 
         Resource resource = new Resource(pid,name,fullName,true,description,name,loginUser.getId(),type,0,now,now);

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ResourcesService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ResourcesService.java
@@ -103,7 +103,10 @@ public class ResourcesService extends BaseService {
             return result;
         }
         String fullName = currentDir.equals("/") ? String.format("%s%s",currentDir,name):String.format("%s/%s",currentDir,name);
-
+        result = verifyResourceName(fullName,type,loginUser);
+        if (!result.getCode().equals(Status.SUCCESS.getCode())) {
+            return result;
+        }
         if (pid != -1) {
             Resource parentResource = resourcesMapper.selectById(pid);
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ResourcesServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ResourcesServiceTest.java
@@ -138,6 +138,10 @@ public class ResourcesServiceTest {
         Assert.assertEquals(Status.HDFS_NOT_STARTUP.getMsg(),result.getMsg());
 
         //PARENT_RESOURCE_NOT_EXIST
+        user.setId(1);
+        user.setTenantId(1);
+        Mockito.when(userMapper.selectById(1)).thenReturn(getUser());
+        Mockito.when(tenantMapper.queryById(1)).thenReturn(getTenant());
         PowerMockito.when(PropertyUtils.getResUploadStartupState()).thenReturn(true);
         Mockito.when(resourcesMapper.selectById(Mockito.anyInt())).thenReturn(null);
         result = resourcesService.createDirectory(user,"directoryTest","directory test",ResourceType.FILE,1,"/");


### PR DESCRIPTION
## What is the purpose of the pull request

*[Fix-3536][api]If user didn't have tenant,create resource directory will NPE*

## Brief change log

*Fix the issue that If user didn't have tenant,create resource directory will NPE*