### PR TITLE
[Improvement][install,start-all,stop-all] start- all.sh and stop- all.sh After execution, you can view the running status of each node and service. #3619

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -98,7 +98,3 @@ sh ${workDir}/script/remove-zk-node.sh $zkRoot
 # 6.startup
 echo "6.startup"
 sh ${workDir}/script/start-all.sh
-
-# 7.query status
-echo "7.query status"
-sh ${workDir}/script/status-all.sh

--- a/script/dolphinscheduler-daemon.sh
+++ b/script/dolphinscheduler-daemon.sh
@@ -29,7 +29,6 @@ shift
 command=$1
 shift
 
-echo "Begin $startStop $command......"
 
 BIN_DIR=`dirname $0`
 BIN_DIR=`cd "$BIN_DIR"; pwd`
@@ -126,10 +125,14 @@ case $startStop in
     # more details about the status can be added later
     serverCount=`ps -ef |grep "$CLASS" |grep -v "grep" |wc -l`
     state="STOP"
+    #  font color - red
+    state="[ \033[1;31m $state \033[0m ]"
     if [[ $serverCount -gt 0 ]];then
       state="RUNNING"
+      # font color - green
+      state="[ \033[1;32m $state \033[0m ]"
     fi
-    echo "$command  $state"
+    echo -e "$command  $state"
     ;;
 
   (*)
@@ -138,5 +141,3 @@ case $startStop in
     ;;
 
 esac
-
-echo "End $startStop $command."

--- a/script/dolphinscheduler-daemon.sh
+++ b/script/dolphinscheduler-daemon.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-usage="Usage: dolphinscheduler-daemon.sh (start|stop) <command> "
+usage="Usage: dolphinscheduler-daemon.sh (start|stop|status) <command> "
 
 # if no args specified, show usage
 if [ $# -le 1 ]; then
@@ -121,6 +121,16 @@ case $startStop in
         echo no $command to stop
       fi
       ;;
+
+  (status)
+    # more details about the status can be added later
+    serverCount=`ps -ef |grep "$CLASS" |grep -v "grep" |wc -l`
+    state="STOP"
+    if [[ $serverCount -gt 0 ]];then
+      state="RUNNING"
+    fi
+    echo "$command  $state"
+    ;;
 
   (*)
     echo $usage

--- a/script/start-all.sh
+++ b/script/start-all.sh
@@ -55,3 +55,7 @@ do
   echo "$apiServer worker server is starting"
   ssh -p $sshPort $apiServer  "cd $installPath/; sh bin/dolphinscheduler-daemon.sh start api-server;"
 done
+
+# query server status
+echo "query server status"
+cd $installPath/; sh bin/status-all.sh

--- a/script/status-all.sh
+++ b/script/status-all.sh
@@ -20,22 +20,63 @@ workDir=`dirname $0`
 workDir=`cd ${workDir};pwd`
 source $workDir/../conf/config/install_config.conf
 
+# install_config.conf info
 echo -e '\n'
-echo "====================== dolphinscheduler install config============================="
-echo -e "1.dolphinscheduler server node install hosts:[ \033[1;32m ${ips} \033[0m ]"
-echo -e "2.master server node install hosts:[ \033[1;32m ${masters} \033[0m ]"
-echo -e "3.worker server node install hosts:[ \033[1;32m ${workers} \033[0m ]"
-echo -e "4.alert server node install hosts:[ \033[1;32m ${alertServer} \033[0m ]"
-echo -e "5.api server node install hosts:[ \033[1;32m ${apiServers} \033[0m ]"
-
+echo "====================== dolphinscheduler server config ============================="
+echo -e "1.dolphinscheduler server node config hosts:[ \033[1;32m ${ips} \033[0m ]"
+echo -e "2.master server node config hosts:[ \033[1;32m ${masters} \033[0m ]"
+echo -e "3.worker server node config hosts:[ \033[1;32m ${workers} \033[0m ]"
+echo -e "4.alert server node config hosts:[ \033[1;32m ${alertServer} \033[0m ]"
+echo -e "5.api server node config hosts:[ \033[1;32m ${apiServers} \033[0m ]"
 echo -e '\n'
 
+# all server check state
+echo -e '\n'
+echo "====================== dolphinscheduler server status ============================="
+firstColumn="node  server  state"
+echo $firstColumn
+echo -e '\n'
 
-ipsHost=(${ips//,/ })
-for ip in ${ipsHost[@]}
+declare -A workersGroupMap=()
+
+workersGroup=(${workers//,/ })
+for workerGroup in ${workersGroup[@]}
 do
-  echo -e "====================== [ \033[1;32m ${ip} \033[0m ] node all servers =========================="
-	ssh -p $sshPort $ip  "jps"
-  echo -e '\n'
+  worker=`echo $workerGroup|awk -F':' '{print $1}'`
+  groupName=`echo $workerGroup|awk -F':' '{print $2}'`
+  workersGroupMap+=([$worker]=$groupName)
 done
+
+# 1.master server check state
+mastersHost=(${masters//,/ })
+for master in ${mastersHost[@]}
+do
+  echo "$master  `ssh -p $sshPort $master  "cd $installPath/; sh bin/dolphinscheduler-daemon.sh status master-server;"`"
+done
+
+# 2.worker server and logger-server check state
+for worker in ${!workersGroupMap[*]}
+do
+  workerState=`ssh -p $sshPort $worker  "cd $installPath/; sh bin/dolphinscheduler-daemon.sh status worker-server;"`
+  echo "$worker  $workerState"
+
+  masterState=`ssh -p $sshPort $worker  "cd $installPath/; sh bin/dolphinscheduler-daemon.sh status logger-server;"`
+  echo "$worker  $masterState"
+done
+
+# 3.alter server check state
+alertState=`ssh -p $sshPort $alertServer  "cd $installPath/; sh bin/dolphinscheduler-daemon.sh status alert-server;"`
+echo "$alertServer  $alertState"
+
+# 4.api server check state
+apiServersHost=(${apiServers//,/ })
+for apiServer in ${apiServersHost[@]}
+do
+  apiState=`ssh -p $sshPort $apiServer  "cd $installPath/; sh bin/dolphinscheduler-daemon.sh status api-server;"`
+  echo "$apiServer  $apiState"
+done
+
+# 5.
+echo -e '\n'
+echo -e "1.master server config hosts:[ \033[1;32m ${masters} \033[0m ],running:[ \033[1;32m ${masters} \033[0m ],stop:[ \033[1;32m ${masters} \033[0m ]"
 

--- a/script/status-all.sh
+++ b/script/status-all.sh
@@ -28,7 +28,6 @@ echo -e "2.master server node config hosts:[ \033[1;32m ${masters} \033[0m ]"
 echo -e "3.worker server node config hosts:[ \033[1;32m ${workers} \033[0m ]"
 echo -e "4.alert server node config hosts:[ \033[1;32m ${alertServer} \033[0m ]"
 echo -e "5.api server node config hosts:[ \033[1;32m ${apiServers} \033[0m ]"
-echo -e '\n'
 
 # all server check state
 echo -e '\n'
@@ -47,11 +46,13 @@ do
   workersGroupMap+=([$worker]=$groupName)
 done
 
+StateRunning="Running"
 # 1.master server check state
 mastersHost=(${masters//,/ })
 for master in ${mastersHost[@]}
 do
-  echo "$master  `ssh -p $sshPort $master  "cd $installPath/; sh bin/dolphinscheduler-daemon.sh status master-server;"`"
+  masterState=`ssh -p $sshPort $master  "cd $installPath/; sh bin/dolphinscheduler-daemon.sh status master-server;"`
+  echo "$master  $masterState"
 done
 
 # 2.worker server and logger-server check state
@@ -75,8 +76,3 @@ do
   apiState=`ssh -p $sshPort $apiServer  "cd $installPath/; sh bin/dolphinscheduler-daemon.sh status api-server;"`
   echo "$apiServer  $apiState"
 done
-
-# 5.
-echo -e '\n'
-echo -e "1.master server config hosts:[ \033[1;32m ${masters} \033[0m ],running:[ \033[1;32m ${masters} \033[0m ],stop:[ \033[1;32m ${masters} \033[0m ]"
-

--- a/script/stop-all.sh
+++ b/script/stop-all.sh
@@ -55,3 +55,7 @@ do
   echo "$apiServer worker server is stopping"
   ssh -p $sshPort $apiServer  "cd $installPath/; sh bin/dolphinscheduler-daemon.sh stop api-server;"
 done
+
+# query server status
+echo "query server status"
+cd $installPath/; sh bin/status-all.sh


### PR DESCRIPTION
## What is the purpose of the pull request
#3619
1.start-all.sh and stop- all.sh After execution, you can view the running status of each node and service
2.status-all.sh It can be executed separately to view the running status of each node and service
3. At present, only two kinds of service process states - running and stop are supported, which can be enriched according to the actual situation

## Brief change log

1.dolphinscheduler-deamon.sh Add the status command operation type, which is used to check the running status of the server (only support two kinds of service process status - running and stop, which can be enriched according to the actual situation)
2.status-all.sh New through install_ config reads the service installation node and calls dolphin scheduler- deamon.sh Check status, print service status
3.start-all.sh and stop-all.sh New call status-all.sh , which is used to view the status of various services in the cluster after starting and shutting down the cluster service

## Verify this pull request

This change added tests and can be verified as follows:
  - *Manually verified the change by testing locally.*

![4dd7cccc4c4c83d90011212632cce0c](https://user-images.githubusercontent.com/37063904/91682967-cd8d7900-eb85-11ea-9771-50421c7d8c4b.png)

---

##拉取请求的目的是什么
#3619
1.start-all.sh and stop-all.sh 执行后可查看可查看各节点各服务运行状态
2.status-all.sh 可单独执行，用于查看各节点各服务运行状态
3.目前只支持服务进程状态-RUNNING,STOP两种，后面可以根据实际情况在丰富

##简要变更日志

1.dolphinscheduler-deamon.sh 新增status命令操作类型，用于检查server运行状态（只支持服务进程状态-RUNNING,STOP两种，后面可以根据实际情况在丰富）
2.status-all.sh 新增通过install_confing读取服务安装节点，调用dolphinscheduler-deamon.sh检查状态，打印服务状态
3.start-all.sh and stop-all.sh 新增 调用status-all.sh,用于在启动集群服务和关闭集群服务后可以查看集群各服务状态

##验证此请求

该变更增加了测试，并可通过以下方式进行验证：

-*通过本地测试手动验证更改*

![4dd7cccc4c4c83d90011212632cce0c](https://user-images.githubusercontent.com/37063904/91682967-cd8d7900-eb85-11ea-9771-50421c7d8c4b.png)


