### PR TITLE
[Improvement][server] Refactor code for getTaskLogPath to reduce NPE log during UT

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/ConditionsTaskExecThread.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/ConditionsTaskExecThread.java
@@ -27,6 +27,8 @@ import org.apache.dolphinscheduler.common.utils.*;
 import org.apache.dolphinscheduler.common.utils.LoggerUtils;
 import org.apache.dolphinscheduler.common.utils.NetUtils;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
+import org.apache.dolphinscheduler.server.utils.LogUtils;
+
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
@@ -123,7 +125,7 @@ public class ConditionsTaskExecThread extends MasterBaseTaskExecThread {
     }
 
     private void initTaskParameters() {
-        this.taskInstance.setLogPath(getTaskLogPath(taskInstance));
+        this.taskInstance.setLogPath(LogUtils.getTaskLogPath(taskInstance));
         this.taskInstance.setHost(NetUtils.getHost() + Constants.COLON + masterConfig.getListenPort());
         taskInstance.setState(ExecutionStatus.RUNNING_EXECUTION);
         taskInstance.setStartTime(new Date());

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/DependentTaskExecThread.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/DependentTaskExecThread.java
@@ -14,9 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.dolphinscheduler.server.master.runner;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
+import static org.apache.dolphinscheduler.common.Constants.DEPENDENT_SPLIT;
+
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.DependResult;
 import org.apache.dolphinscheduler.common.enums.ExecutionStatus;
@@ -24,16 +26,22 @@ import org.apache.dolphinscheduler.common.model.DependentTaskModel;
 import org.apache.dolphinscheduler.common.task.dependent.DependentParameters;
 import org.apache.dolphinscheduler.common.thread.Stopper;
 import org.apache.dolphinscheduler.common.utils.DependentUtils;
-import org.apache.dolphinscheduler.common.utils.*;
+import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.common.utils.LoggerUtils;
 import org.apache.dolphinscheduler.common.utils.NetUtils;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
+import org.apache.dolphinscheduler.server.utils.LogUtils;
 import org.apache.dolphinscheduler.server.utils.DependentExecute;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
-
-import static org.apache.dolphinscheduler.common.Constants.DEPENDENT_SPLIT;
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 public class DependentTaskExecThread extends MasterBaseTaskExecThread {
 
@@ -172,7 +180,7 @@ public class DependentTaskExecThread extends MasterBaseTaskExecThread {
     }
 
     private void initTaskParameters() {
-        taskInstance.setLogPath(getTaskLogPath(taskInstance));
+        taskInstance.setLogPath(LogUtils.getTaskLogPath(taskInstance));
         taskInstance.setHost(NetUtils.getHost() + Constants.COLON + masterConfig.getListenPort());
         taskInstance.setState(ExecutionStatus.RUNNING_EXECUTION);
         taskInstance.setStartTime(new Date());

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterBaseTaskExecThread.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterBaseTaskExecThread.java
@@ -24,25 +24,16 @@ import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.dao.AlertDao;
 import org.apache.dolphinscheduler.dao.entity.ProcessInstance;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
-import org.apache.dolphinscheduler.server.log.TaskLogDiscriminator;
 import org.apache.dolphinscheduler.server.master.config.MasterConfig;
 import org.apache.dolphinscheduler.service.bean.SpringApplicationContext;
 import org.apache.dolphinscheduler.service.process.ProcessService;
 import org.apache.dolphinscheduler.service.queue.TaskPriorityQueue;
 import org.apache.dolphinscheduler.service.queue.TaskPriorityQueueImpl;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Optional;
 import java.util.concurrent.Callable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import ch.qos.logback.classic.sift.SiftingAppender;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.spi.AppenderAttachable;
-
 
 /**
  * master task exec base class
@@ -89,11 +80,13 @@ public class MasterBaseTaskExecThread implements Callable<Boolean> {
      * taskUpdateQueue
      */
     private TaskPriorityQueue taskUpdateQueue;
+
     /**
      * constructor of MasterBaseTaskExecThread
-     * @param taskInstance      task instance
+     *
+     * @param taskInstance task instance
      */
-    public MasterBaseTaskExecThread(TaskInstance taskInstance){
+    public MasterBaseTaskExecThread(TaskInstance taskInstance) {
         this.processService = SpringApplicationContext.getBean(ProcessService.class);
         this.alertDao = SpringApplicationContext.getBean(AlertDao.class);
         this.cancel = false;
@@ -104,24 +97,26 @@ public class MasterBaseTaskExecThread implements Callable<Boolean> {
 
     /**
      * get task instance
+     *
      * @return TaskInstance
      */
-    public TaskInstance getTaskInstance(){
+    public TaskInstance getTaskInstance() {
         return this.taskInstance;
     }
 
     /**
      * kill master base task exec thread
      */
-    public void kill(){
+    public void kill() {
         this.cancel = true;
     }
 
     /**
      * submit master base task exec thread
+     *
      * @return TaskInstance
      */
-    protected TaskInstance submit(){
+    protected TaskInstance submit() {
         Integer commitRetryTimes = masterConfig.getMasterTaskCommitRetryTimes();
         Integer commitRetryInterval = masterConfig.getMasterTaskCommitInterval();
 
@@ -160,14 +155,13 @@ public class MasterBaseTaskExecThread implements Callable<Boolean> {
     }
 
 
-
     /**
      * dispatcht task
+     *
      * @param taskInstance taskInstance
      * @return whether submit task success
      */
     public Boolean dispatchTask(TaskInstance taskInstance) {
-
         try{
             if(taskInstance.isConditionsTask()
                     || taskInstance.isDependTask()
@@ -206,7 +200,7 @@ public class MasterBaseTaskExecThread implements Callable<Boolean> {
 
 
     /**
-     *  buildTaskPriorityInfo
+     * buildTaskPriorityInfo
      *
      * @param processInstancePriority processInstancePriority
      * @param processInstanceId processInstanceId
@@ -219,7 +213,7 @@ public class MasterBaseTaskExecThread implements Callable<Boolean> {
                                          int processInstanceId,
                                          int taskInstancePriority,
                                          int taskInstanceId,
-                                         String workerGroup){
+                                         String workerGroup) {
         return processInstancePriority +
                 UNDERLINE +
                 processInstanceId +
@@ -233,14 +227,16 @@ public class MasterBaseTaskExecThread implements Callable<Boolean> {
 
     /**
      * submit wait complete
+     *
      * @return true
      */
-    protected Boolean submitWaitComplete(){
+    protected Boolean submitWaitComplete() {
         return true;
     }
 
     /**
      * call
+     *
      * @return boolean
      * @throws Exception exception
      */
@@ -248,35 +244,6 @@ public class MasterBaseTaskExecThread implements Callable<Boolean> {
     public Boolean call() throws Exception {
         this.processInstance = processService.findProcessInstanceById(taskInstance.getProcessInstanceId());
         return submitWaitComplete();
-    }
-
-    /**
-     * get task log path
-     *
-     * @return log path
-     */
-    @SuppressWarnings("unchecked")
-    public String getTaskLogPath(TaskInstance task) {
-        try {
-            // Optional.map will be skipped if null
-            Path path = Optional.of(LoggerFactory.getILoggerFactory())
-                    .map(e -> (AppenderAttachable<ILoggingEvent>) (e.getLogger("ROOT")))
-                    .map(e -> (SiftingAppender) (e.getAppender("TASKLOGFILE")))
-                    .map(e -> ((TaskLogDiscriminator) (e.getDiscriminator())))
-                    .map(TaskLogDiscriminator::getLogBase)
-                    .map(e -> Paths.get(e)
-                            .toAbsolutePath()
-                            .resolve(String.valueOf(task.getProcessDefinitionId()))
-                            .resolve(String.valueOf(task.getProcessInstanceId()))
-                            .resolve(task.getId() + ".log"))
-                    .orElse(null);
-            if (path != null) {
-                return path.toString();
-            }
-        } catch (Exception e) {
-            logger.error("logger", e);
-        }
-        return "";
     }
 
 }

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterBaseTaskExecThread.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterBaseTaskExecThread.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.dolphinscheduler.server.master.runner;
 
 import static org.apache.dolphinscheduler.common.Constants.UNDERLINE;

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterBaseTaskExecThread.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterBaseTaskExecThread.java
@@ -18,7 +18,6 @@ package org.apache.dolphinscheduler.server.master.runner;
 
 import static org.apache.dolphinscheduler.common.Constants.UNDERLINE;
 
-import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.ExecutionStatus;
 import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.dao.AlertDao;
@@ -31,13 +30,17 @@ import org.apache.dolphinscheduler.service.process.ProcessService;
 import org.apache.dolphinscheduler.service.queue.TaskPriorityQueue;
 import org.apache.dolphinscheduler.service.queue.TaskPriorityQueueImpl;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.sift.SiftingAppender;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.spi.AppenderAttachable;
 
 
 /**
@@ -248,32 +251,31 @@ public class MasterBaseTaskExecThread implements Callable<Boolean> {
 
     /**
      * get task log path
+     *
      * @return log path
      */
+    @SuppressWarnings("unchecked")
     public String getTaskLogPath(TaskInstance task) {
-        String logPath;
-        try{
-            String baseLog = ((TaskLogDiscriminator) ((SiftingAppender) ((LoggerContext) LoggerFactory.getILoggerFactory())
-                    .getLogger("ROOT")
-                    .getAppender("TASKLOGFILE"))
-                    .getDiscriminator()).getLogBase();
-            if (baseLog.startsWith(Constants.SINGLE_SLASH)){
-                logPath =  baseLog + Constants.SINGLE_SLASH +
-                        task.getProcessDefinitionId() + Constants.SINGLE_SLASH  +
-                        task.getProcessInstanceId() + Constants.SINGLE_SLASH  +
-                        task.getId() + ".log";
-            }else{
-                logPath = System.getProperty("user.dir") + Constants.SINGLE_SLASH +
-                        baseLog +  Constants.SINGLE_SLASH +
-                        task.getProcessDefinitionId() + Constants.SINGLE_SLASH  +
-                        task.getProcessInstanceId() + Constants.SINGLE_SLASH  +
-                        task.getId() + ".log";
+        try {
+            // Optional.map will be skipped if null
+            Path path = Optional.of(LoggerFactory.getILoggerFactory())
+                    .map(e -> (AppenderAttachable<ILoggingEvent>) (e.getLogger("ROOT")))
+                    .map(e -> (SiftingAppender) (e.getAppender("TASKLOGFILE")))
+                    .map(e -> ((TaskLogDiscriminator) (e.getDiscriminator())))
+                    .map(TaskLogDiscriminator::getLogBase)
+                    .map(e -> Paths.get(e)
+                            .toAbsolutePath()
+                            .resolve(String.valueOf(task.getProcessDefinitionId()))
+                            .resolve(String.valueOf(task.getProcessInstanceId()))
+                            .resolve(task.getId() + ".log"))
+                    .orElse(null);
+            if (path != null) {
+                return path.toString();
             }
-        }catch (Exception e){
+        } catch (Exception e) {
             logger.error("logger", e);
-            logPath = "";
         }
-        return logPath;
+        return "";
     }
 
 }

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/LogUtils.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/LogUtils.java
@@ -17,7 +17,6 @@
 
 package org.apache.dolphinscheduler.server.utils;
 
-import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.server.entity.TaskExecutionContext;
 import org.apache.dolphinscheduler.server.log.TaskLogDiscriminator;
@@ -28,7 +27,6 @@ import java.util.Optional;
 
 import org.slf4j.LoggerFactory;
 
-import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.sift.SiftingAppender;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.spi.AppenderAttachable;

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/LogUtils.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/LogUtils.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.server.utils;
+
+import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.dao.entity.TaskInstance;
+import org.apache.dolphinscheduler.server.entity.TaskExecutionContext;
+import org.apache.dolphinscheduler.server.log.TaskLogDiscriminator;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.sift.SiftingAppender;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.spi.AppenderAttachable;
+
+public class LogUtils {
+
+    /**
+     * get task log path
+     */
+    @SuppressWarnings("unchecked")
+    private static String getTaskLogPath(int processDefinitionId, int processInstanceId, int taskInstanceId) {
+        // Optional.map will be skipped if null
+        return Optional.of(LoggerFactory.getILoggerFactory())
+                .map(e -> (AppenderAttachable<ILoggingEvent>) (e.getLogger("ROOT")))
+                .map(e -> (SiftingAppender) (e.getAppender("TASKLOGFILE")))
+                .map(e -> ((TaskLogDiscriminator) (e.getDiscriminator())))
+                .map(TaskLogDiscriminator::getLogBase)
+                .map(e -> Paths.get(e)
+                        .toAbsolutePath()
+                        .resolve(String.valueOf(processDefinitionId))
+                        .resolve(String.valueOf(processInstanceId))
+                        .resolve(taskInstanceId + ".log"))
+                .map(Path::toString)
+                .orElse("");
+    }
+
+    /**
+     * get task log path by TaskInstance
+     */
+    public static String getTaskLogPath(TaskInstance taskInstance) {
+        return getTaskLogPath(taskInstance.getProcessDefinitionId(), taskInstance.getProcessInstanceId(), taskInstance.getId());
+    }
+
+    /**
+     * get task log path by TaskExecutionContext
+     */
+    public static String getTaskLogPath(TaskExecutionContext taskExecutionContext) {
+        return getTaskLogPath(taskExecutionContext.getProcessId(), taskExecutionContext.getProcessInstanceId(), taskExecutionContext.getTaskInstanceId());
+    }
+
+}

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/LogUtils.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/LogUtils.java
@@ -33,6 +33,9 @@ import ch.qos.logback.core.spi.AppenderAttachable;
 
 public class LogUtils {
 
+    private LogUtils() {
+    }
+
     /**
      * get task log path
      */

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/LogUtils.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/LogUtils.java
@@ -25,6 +25,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
 
+import javax.transaction.NotSupportedException;
+
 import org.slf4j.LoggerFactory;
 
 import ch.qos.logback.classic.sift.SiftingAppender;
@@ -33,7 +35,8 @@ import ch.qos.logback.core.spi.AppenderAttachable;
 
 public class LogUtils {
 
-    private LogUtils() {
+    private LogUtils() throws NotSupportedException {
+        throw new NotSupportedException();
     }
 
     /**

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskExecuteProcessor.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/processor/TaskExecuteProcessor.java
@@ -17,8 +17,6 @@
 
 package org.apache.dolphinscheduler.server.worker.processor;
 
-
-import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.ExecutionStatus;
 import org.apache.dolphinscheduler.common.enums.TaskType;
 import org.apache.dolphinscheduler.common.thread.ThreadUtils;
@@ -36,7 +34,7 @@ import org.apache.dolphinscheduler.remote.command.TaskExecuteRequestCommand;
 import org.apache.dolphinscheduler.remote.processor.NettyRequestProcessor;
 import org.apache.dolphinscheduler.remote.utils.JsonSerializer;
 import org.apache.dolphinscheduler.server.entity.TaskExecutionContext;
-import org.apache.dolphinscheduler.server.log.TaskLogDiscriminator;
+import org.apache.dolphinscheduler.server.utils.LogUtils;
 import org.apache.dolphinscheduler.server.worker.config.WorkerConfig;
 import org.apache.dolphinscheduler.server.worker.runner.TaskExecuteThread;
 import org.apache.dolphinscheduler.service.bean.SpringApplicationContext;
@@ -51,8 +49,6 @@ import org.slf4j.LoggerFactory;
 
 import com.github.rholder.retry.RetryException;
 
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.sift.SiftingAppender;
 import io.netty.channel.Channel;
 
 /**
@@ -155,28 +151,6 @@ public class TaskExecuteProcessor implements NettyRequestProcessor {
     }
 
     /**
-     * get task log path
-     * @return log path
-     */
-    private String getTaskLogPath(TaskExecutionContext taskExecutionContext) {
-        String baseLog = ((TaskLogDiscriminator) ((SiftingAppender) ((LoggerContext) LoggerFactory.getILoggerFactory())
-                .getLogger("ROOT")
-                .getAppender("TASKLOGFILE"))
-                .getDiscriminator()).getLogBase();
-        if (baseLog.startsWith(Constants.SINGLE_SLASH)){
-            return baseLog + Constants.SINGLE_SLASH +
-                    taskExecutionContext.getProcessDefineId() + Constants.SINGLE_SLASH  +
-                    taskExecutionContext.getProcessInstanceId() + Constants.SINGLE_SLASH  +
-                    taskExecutionContext.getTaskInstanceId() + ".log";
-        }
-        return System.getProperty("user.dir") + Constants.SINGLE_SLASH +
-                baseLog +  Constants.SINGLE_SLASH +
-                taskExecutionContext.getProcessDefineId() + Constants.SINGLE_SLASH  +
-                taskExecutionContext.getProcessInstanceId() + Constants.SINGLE_SLASH  +
-                taskExecutionContext.getTaskInstanceId() + ".log";
-    }
-
-    /**
      * build ack command
      * @param taskExecutionContext taskExecutionContext
      * @return TaskExecuteAckCommand
@@ -185,7 +159,7 @@ public class TaskExecuteProcessor implements NettyRequestProcessor {
         TaskExecuteAckCommand ackCommand = new TaskExecuteAckCommand();
         ackCommand.setTaskInstanceId(taskExecutionContext.getTaskInstanceId());
         ackCommand.setStatus(taskExecutionContext.getCurrentExecutionStatus().getCode());
-        ackCommand.setLogPath(getTaskLogPath(taskExecutionContext));
+        ackCommand.setLogPath(LogUtils.getTaskLogPath(taskExecutionContext));
         ackCommand.setHost(taskExecutionContext.getHost());
         ackCommand.setStartTime(taskExecutionContext.getStartTime());
         if(taskExecutionContext.getTaskType().equals(TaskType.SQL.name()) || taskExecutionContext.getTaskType().equals(TaskType.PROCEDURE.name())){

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/runner/MasterTaskExecThreadTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/runner/MasterTaskExecThreadTest.java
@@ -17,16 +17,12 @@
 
 package org.apache.dolphinscheduler.server.master.runner;
 
-import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.ExecutionStatus;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
-import org.apache.dolphinscheduler.server.log.TaskLogDiscriminator;
 import org.apache.dolphinscheduler.server.registry.ZookeeperRegistryCenter;
 import org.apache.dolphinscheduler.service.bean.SpringApplicationContext;
 import org.apache.dolphinscheduler.service.process.ProcessService;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -38,13 +34,9 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 
 import com.google.common.collect.Sets;
-
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.sift.SiftingAppender;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
 @PrepareForTest(MasterTaskExecThread.class)

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/runner/MasterTaskExecThreadTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/runner/MasterTaskExecThreadTest.java
@@ -17,14 +17,19 @@
 
 package org.apache.dolphinscheduler.server.master.runner;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.ExecutionStatus;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
+import org.apache.dolphinscheduler.server.log.TaskLogDiscriminator;
 import org.apache.dolphinscheduler.server.registry.ZookeeperRegistryCenter;
 import org.apache.dolphinscheduler.service.bean.SpringApplicationContext;
 import org.apache.dolphinscheduler.service.process.ProcessService;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,9 +38,13 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 
 import com.google.common.collect.Sets;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.sift.SiftingAppender;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
 @PrepareForTest(MasterTaskExecThread.class)
@@ -106,6 +115,38 @@ public class MasterTaskExecThreadTest {
         MasterTaskExecThread masterTaskExecThread = new MasterTaskExecThread(taskInstance);
         masterTaskExecThread.pauseTask();
         org.junit.Assert.assertEquals(ExecutionStatus.PAUSE, taskInstance.getState());
+    }
+
+    @Test
+    public void testGetTaskLogPath() {
+        TaskInstance taskInstance = new TaskInstance();
+        taskInstance.setProcessDefinitionId(1);
+        taskInstance.setProcessInstanceId(100);
+        taskInstance.setId(1000);
+
+        Logger rootLogger = (Logger) LoggerFactory.getILoggerFactory().getLogger("ROOT");
+        Assert.assertNotNull(rootLogger);
+
+        MasterTaskExecThread taskExecThread = new MasterTaskExecThread(taskInstance);
+
+        Assert.assertEquals("/", Constants.SINGLE_SLASH);
+        Assert.assertEquals("", taskExecThread.getTaskLogPath(taskInstance));
+
+        SiftingAppender appender = PowerMockito.mock(SiftingAppender.class);
+        // it's a trick to mock logger.getAppend("TASKLOGFILE")
+        PowerMockito.when(appender.getName()).thenReturn("TASKLOGFILE");
+        rootLogger.addAppender(appender);
+
+        Path logBase = Paths.get("path").resolve("to").resolve("test");
+
+        TaskLogDiscriminator taskLogDiscriminator = PowerMockito.mock(TaskLogDiscriminator.class);
+        PowerMockito.when(taskLogDiscriminator.getLogBase()).thenReturn(logBase.toString());
+        PowerMockito.when(appender.getDiscriminator()).thenReturn(taskLogDiscriminator);
+
+        Path logPath = Paths.get(".").toAbsolutePath().getParent()
+                .resolve(logBase)
+                .resolve("1").resolve("100").resolve("1000.log");
+        Assert.assertEquals(logPath.toString(), taskExecThread.getTaskLogPath(taskInstance));
     }
 
     private TaskInstance getTaskInstance(){

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/runner/MasterTaskExecThreadTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/runner/MasterTaskExecThreadTest.java
@@ -132,16 +132,16 @@ public class MasterTaskExecThreadTest {
         Assert.assertEquals("/", Constants.SINGLE_SLASH);
         Assert.assertEquals("", taskExecThread.getTaskLogPath(taskInstance));
 
-        SiftingAppender appender = PowerMockito.mock(SiftingAppender.class);
+        SiftingAppender appender = Mockito.mock(SiftingAppender.class);
         // it's a trick to mock logger.getAppend("TASKLOGFILE")
-        PowerMockito.when(appender.getName()).thenReturn("TASKLOGFILE");
+        Mockito.when(appender.getName()).thenReturn("TASKLOGFILE");
         rootLogger.addAppender(appender);
 
         Path logBase = Paths.get("path").resolve("to").resolve("test");
 
-        TaskLogDiscriminator taskLogDiscriminator = PowerMockito.mock(TaskLogDiscriminator.class);
-        PowerMockito.when(taskLogDiscriminator.getLogBase()).thenReturn(logBase.toString());
-        PowerMockito.when(appender.getDiscriminator()).thenReturn(taskLogDiscriminator);
+        TaskLogDiscriminator taskLogDiscriminator = Mockito.mock(TaskLogDiscriminator.class);
+        Mockito.when(taskLogDiscriminator.getLogBase()).thenReturn(logBase.toString());
+        Mockito.when(appender.getDiscriminator()).thenReturn(taskLogDiscriminator);
 
         Path logPath = Paths.get(".").toAbsolutePath().getParent()
                 .resolve(logBase)

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/runner/MasterTaskExecThreadTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/runner/MasterTaskExecThreadTest.java
@@ -117,38 +117,6 @@ public class MasterTaskExecThreadTest {
         org.junit.Assert.assertEquals(ExecutionStatus.PAUSE, taskInstance.getState());
     }
 
-    @Test
-    public void testGetTaskLogPath() {
-        TaskInstance taskInstance = new TaskInstance();
-        taskInstance.setProcessDefinitionId(1);
-        taskInstance.setProcessInstanceId(100);
-        taskInstance.setId(1000);
-
-        Logger rootLogger = (Logger) LoggerFactory.getILoggerFactory().getLogger("ROOT");
-        Assert.assertNotNull(rootLogger);
-
-        MasterTaskExecThread taskExecThread = new MasterTaskExecThread(taskInstance);
-
-        Assert.assertEquals("/", Constants.SINGLE_SLASH);
-        Assert.assertEquals("", taskExecThread.getTaskLogPath(taskInstance));
-
-        SiftingAppender appender = Mockito.mock(SiftingAppender.class);
-        // it's a trick to mock logger.getAppend("TASKLOGFILE")
-        Mockito.when(appender.getName()).thenReturn("TASKLOGFILE");
-        rootLogger.addAppender(appender);
-
-        Path logBase = Paths.get("path").resolve("to").resolve("test");
-
-        TaskLogDiscriminator taskLogDiscriminator = Mockito.mock(TaskLogDiscriminator.class);
-        Mockito.when(taskLogDiscriminator.getLogBase()).thenReturn(logBase.toString());
-        Mockito.when(appender.getDiscriminator()).thenReturn(taskLogDiscriminator);
-
-        Path logPath = Paths.get(".").toAbsolutePath().getParent()
-                .resolve(logBase)
-                .resolve("1").resolve("100").resolve("1000.log");
-        Assert.assertEquals(logPath.toString(), taskExecThread.getTaskLogPath(taskInstance));
-    }
-
     private TaskInstance getTaskInstance(){
         TaskInstance taskInstance = new TaskInstance();
         taskInstance.setTaskType("SHELL");

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/utils/LogUtilsTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/utils/LogUtilsTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.dolphinscheduler.server.utils;
 
-import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.server.log.TaskLogDiscriminator;
 
@@ -39,8 +38,6 @@ public class LogUtilsTest {
 
     @Test
     public void testGetTaskLogPath() {
-        Assert.assertEquals("/", Constants.SINGLE_SLASH);
-
         TaskInstance taskInstance = new TaskInstance();
         taskInstance.setProcessDefinitionId(1);
         taskInstance.setProcessInstanceId(100);

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/utils/LogUtilsTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/utils/LogUtilsTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.server.utils;
+
+import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.dao.entity.TaskInstance;
+import org.apache.dolphinscheduler.server.log.TaskLogDiscriminator;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.sift.SiftingAppender;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LogUtilsTest {
+
+    @Test
+    public void testGetTaskLogPath() {
+        Assert.assertEquals("/", Constants.SINGLE_SLASH);
+
+        TaskInstance taskInstance = new TaskInstance();
+        taskInstance.setProcessDefinitionId(1);
+        taskInstance.setProcessInstanceId(100);
+        taskInstance.setId(1000);
+
+        Logger rootLogger = (Logger) LoggerFactory.getILoggerFactory().getLogger("ROOT");
+        Assert.assertNotNull(rootLogger);
+
+        SiftingAppender appender = Mockito.mock(SiftingAppender.class);
+        // it's a trick to mock logger.getAppend("TASKLOGFILE")
+        Mockito.when(appender.getName()).thenReturn("TASKLOGFILE");
+        rootLogger.addAppender(appender);
+
+        Path logBase = Paths.get("path").resolve("to").resolve("test");
+
+        TaskLogDiscriminator taskLogDiscriminator = Mockito.mock(TaskLogDiscriminator.class);
+        Mockito.when(taskLogDiscriminator.getLogBase()).thenReturn(logBase.toString());
+        Mockito.when(appender.getDiscriminator()).thenReturn(taskLogDiscriminator);
+
+        Path logPath = Paths.get(".").toAbsolutePath().getParent()
+                .resolve(logBase)
+                .resolve("1").resolve("100").resolve("1000.log");
+        Assert.assertEquals(logPath.toString(), LogUtils.getTaskLogPath(taskInstance));
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -831,6 +831,7 @@
                         <include>**/server/utils/DataxUtilsTest.java</include>
                         <include>**/server/utils/ExecutionContextTestUtils.java</include>
                         <!--<include>**/server/utils/FlinkArgsUtilsTest.java</include>-->
+                        <include>**/server/utils/LogUtilsTest.java</include>
                         <include>**/server/utils/ParamUtilsTest.java</include>
                         <include>**/server/utils/ProcessUtilsTest.java</include>
                         <include>**/server/utils/SparkArgsUtilsTest.java</include>


### PR DESCRIPTION
## What is the purpose of the pull request

- Refactor code for getTaskLogPath to reduce NPE log during UT

## Brief change log

- Add `org.apache.dolphinscheduler.server.utils.LogUtils`
- Remove `MasterBaseTaskExecThread.getTaskLogPath`
- Remove `org.apache.dolphinscheduler.server.worker.processor.TaskExecuteProcessor.getTaskLogPath`

## Verify this pull request

This change added tests and can be verified as follows:

- Added `org.apache.dolphinscheduler.server.utils.LogUtilsTest`.
- Tested locally.
