### PR TITLE
[Feature-2127][worker] fix get yarn applications status from yarn server,http code return 404, get yarn applications status cause NullPointerException

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HadoopUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HadoopUtils.java
@@ -426,7 +426,7 @@ public class HadoopUtils implements Closeable {
         if (responseContent != null) {
             ObjectNode jsonObject = JSONUtils.parseObject(responseContent);
 	    if(!jsonObject.has("app")){
-		    return return ExecutionStatus.FAILURE;
+		    return  ExecutionStatus.FAILURE;
 	    }
 		result = jsonObject.path("app").path("finalStatus").asText();
       

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HadoopUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HadoopUtils.java
@@ -443,7 +443,7 @@ public class HadoopUtils implements Closeable {
            		 result = jsonObject.path("job").path("state").asText();
 		}
 		else{
-		    return return ExecutionStatus.FAILURE;
+		    return ExecutionStatus.FAILURE;
 		}
         }
 

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HadoopUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HadoopUtils.java
@@ -425,17 +425,26 @@ public class HadoopUtils implements Closeable {
 		}
         if (responseContent != null) {
             ObjectNode jsonObject = JSONUtils.parseObject(responseContent);
-            result = jsonObject.path("app").path("finalStatus").asText();
+	    if(!jsonObject.has("app")){
+		    return return ExecutionStatus.FAILURE;
+	    }
+		result = jsonObject.path("app").path("finalStatus").asText();
+      
         } else {
             //may be in job history
             String jobHistoryUrl = getJobHistoryUrl(applicationId);
             logger.info("jobHistoryUrl={}", jobHistoryUrl);
             responseContent = HttpUtils.get(jobHistoryUrl);
-            ObjectNode jsonObject = JSONUtils.parseObject(responseContent);
-            if (!jsonObject.has("job")){
-                return ExecutionStatus.FAILURE;
-            }
-            result = jsonObject.path("job").path("state").asText();
+		if(null != responseContent){
+		   ObjectNode jsonObject = JSONUtils.parseObject(responseContent);
+            		if (!jsonObject.has("job")){
+                     		return ExecutionStatus.FAILURE;
+            		}
+           		 result = jsonObject.path("job").path("state").asText();
+		}
+		else{
+		    return return ExecutionStatus.FAILURE;
+		}
         }
 
         switch (result) {


### PR DESCRIPTION
fix get yarn applications status from yarn server,http code return 404, get yarn applications status cause NullPointerException

## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds checkstyle plugin.)*

## Brief change log

*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.*
