### PR TITLE
add 4lw.commands.whitelist for ds monitor

### DIFF
--- a/docker/build/conf/zookeeper/zoo.cfg
+++ b/docker/build/conf/zookeeper/zoo.cfg
@@ -43,3 +43,5 @@ clientPort=2181
 # Purge task interval in hours
 # Set to "0" to disable auto purge feature
 #autopurge.purgeInterval=1
+#Four Letter Words commands:stat,ruok,conf,isro
+4lw.commands.whitelist=*


### PR DESCRIPTION

## What is the purpose of the pull request
add config to enable dolphinscheuler monitor data
```
#Four Letter Words commands:stat,ruok,conf,isro
4lw.commands.whitelist=*
```
if without this config,the monitor data is all  default value -1
