### PR TITLE
[Improvement-3690][common] Get the native IP policy problem (获取本机ip策略问题 )

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/Constants.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/Constants.java
@@ -1000,4 +1000,9 @@ public final class Constants {
     public static final String DATASOURCE_ENCRYPTION_SALT_DEFAULT = "!@#$%^&*";
     public static final String DATASOURCE_ENCRYPTION_ENABLE = "datasource.encryption.enable";
     public static final String DATASOURCE_ENCRYPTION_SALT = "datasource.encryption.salt";
+
+    /**
+     * Network IP gets priority, default inner outer
+     */
+    public static final String NETWORK_PRIORITY_STRATEGY = "dolphin.scheduler.network.priority.strategy";
 }

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/NetUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/NetUtils.java
@@ -236,7 +236,7 @@ public class NetUtils {
      */
     public static NetworkInterface findIntranetAddress(List<NetworkInterface> validNetworkInterfaces) {
 
-        if (validNetworkInterfaces.size() == 0) {
+        if (validNetworkInterfaces.isEmpty()) {
             return null;
         }
         NetworkInterface networkInterface = null;

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/NetUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/NetUtils.java
@@ -273,8 +273,7 @@ public class NetUtils {
             while (address.hasMoreElements()) {
                 InetAddress ip = address.nextElement();
                 if (ip.isSiteLocalAddress()
-                        && !ip.isLoopbackAddress()
-                        && !ip.getHostAddress().contains(":")) {
+                        && !ip.isLoopbackAddress()) {
                     networkInterface = ni;
                 }
             }
@@ -289,8 +288,7 @@ public class NetUtils {
             while (address.hasMoreElements()) {
                 InetAddress ip = address.nextElement();
                 if (!ip.isSiteLocalAddress()
-                        && !ip.isLoopbackAddress()
-                        && !ip.getHostAddress().contains(":")) {
+                        && !ip.isLoopbackAddress()) {
                     networkInterface = ni;
                 }
             }

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/NetUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/NetUtils.java
@@ -89,21 +89,22 @@ public class NetUtils {
         }
         InetAddress localAddress = null;
         NetworkInterface networkInterface = findNetworkInterface();
-        Enumeration<InetAddress> addresses = networkInterface.getInetAddresses();
-        while (addresses.hasMoreElements()) {
-            Optional<InetAddress> addressOp = toValidAddress(addresses.nextElement());
-            if (addressOp.isPresent()) {
-                try {
-                    if (addressOp.get().isReachable(100)) {
-                        LOCAL_ADDRESS = addressOp.get();
-                        return LOCAL_ADDRESS;
+        if (networkInterface != null) {
+            Enumeration<InetAddress> addresses = networkInterface.getInetAddresses();
+            while (addresses.hasMoreElements()) {
+                Optional<InetAddress> addressOp = toValidAddress(addresses.nextElement());
+                if (addressOp.isPresent()) {
+                    try {
+                        if (addressOp.get().isReachable(100)) {
+                            LOCAL_ADDRESS = addressOp.get();
+                            return LOCAL_ADDRESS;
+                        }
+                    } catch (IOException e) {
+                        logger.warn("test address id reachable io exception", e);
                     }
-                } catch (IOException e) {
-                    logger.warn("test address id reachable io exception", e);
                 }
             }
         }
-
         try {
             localAddress = InetAddress.getLocalHost();
         } catch (UnknownHostException e) {

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/NetUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/NetUtils.java
@@ -235,7 +235,7 @@ public class NetUtils {
         if (validNetworkInterfaces.isEmpty()) {
             return null;
         }
-        String networkPriority = PropertyUtils.getString(Constants.NETWORK_PRIORITY_STRATEGY, "default");
+        String networkPriority = PropertyUtils.getString(Constants.NETWORK_PRIORITY_STRATEGY, NETWORK_PRIORITY_DEFAULT);
         if (NETWORK_PRIORITY_DEFAULT.equalsIgnoreCase(networkPriority)) {
             return findAddressByDefaultPolicy(validNetworkInterfaces);
         } else if (NETWORK_PRIORITY_INNER.equalsIgnoreCase(networkPriority)) {

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/NetUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/NetUtils.java
@@ -190,7 +190,7 @@ public class NetUtils {
         if (null != result) {
             return result;
         }
-        return validNetworkInterfaces.get(0);
+        return findIntranetAddress(validNetworkInterfaces);
     }
 
     /**
@@ -226,5 +226,33 @@ public class NetUtils {
     private static boolean isSpecifyNetworkInterface(NetworkInterface networkInterface) {
         String preferredNetworkInterface = System.getProperty(DOLPHIN_SCHEDULER_PREFERRED_NETWORK_INTERFACE);
         return Objects.equals(networkInterface.getDisplayName(), preferredNetworkInterface);
+    }
+
+    /**
+     * Get the Intranet IP
+     *
+     * @return If no {@link NetworkInterface} is available , return <code>null</code>
+     */
+    public static NetworkInterface findIntranetAddress(List<NetworkInterface> validNetworkInterfaces) {
+
+        if (validNetworkInterfaces.size() == 0) {
+            return null;
+        }
+        NetworkInterface networkInterface = null;
+        for (NetworkInterface ni : validNetworkInterfaces) {
+            Enumeration<InetAddress> address = ni.getInetAddresses();
+            while (address.hasMoreElements()) {
+                InetAddress ip = address.nextElement();
+                if (ip.isSiteLocalAddress()
+                        && !ip.isLoopbackAddress()
+                        && !ip.getHostAddress().contains(":")) {
+                    networkInterface = ni;
+                }
+            }
+        }
+        if (networkInterface == null) {
+            return validNetworkInterfaces.get(0);
+        }
+        return networkInterface;
     }
 }

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/NetUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/NetUtils.java
@@ -48,9 +48,9 @@ public class NetUtils {
     private static final String NETWORK_PRIORITY_DEFAULT = "default";
     private static final String NETWORK_PRIORITY_INNER = "inner";
     private static final String NETWORK_PRIORITY_OUTER = "outer";
-    private static Logger logger = LoggerFactory.getLogger(NetUtils.class);
-    private static String ANY_HOST_VALUE = "0.0.0.0";
-    private static String LOCAL_HOST_VALUE = "127.0.0.1";
+    private static final Logger logger = LoggerFactory.getLogger(NetUtils.class);
+    private static final String ANY_HOST_VALUE = "0.0.0.0";
+    private static final String LOCAL_HOST_VALUE = "127.0.0.1";
     private static InetAddress LOCAL_ADDRESS = null;
     private static volatile String HOST_ADDRESS;
 
@@ -66,7 +66,7 @@ public class NetUtils {
         InetAddress address = getLocalAddress();
         if (address != null) {
             HOST_ADDRESS = address.getHostAddress();
-                    return HOST_ADDRESS;
+            return HOST_ADDRESS;
         }
         return LOCAL_HOST_VALUE;
     }

--- a/dolphinscheduler-common/src/main/resources/common.properties
+++ b/dolphinscheduler-common/src/main/resources/common.properties
@@ -73,6 +73,5 @@ kerberos.expire.time=2
 datasource.encryption.enable=false
 datasource.encryption.salt=!@#$%^&*
 
-#Network IP gets priority, default inner outer
+# Network IP gets priority, default inner outer
 #dolphin.scheduler.network.priority.strategy=default
-

--- a/dolphinscheduler-common/src/main/resources/common.properties
+++ b/dolphinscheduler-common/src/main/resources/common.properties
@@ -72,3 +72,7 @@ kerberos.expire.time=2
 # datasource encryption salt
 datasource.encryption.enable=false
 datasource.encryption.salt=!@#$%^&*
+
+#Network IP gets priority, default inner outer
+#dolphin.scheduler.network.priority.strategy=default
+


### PR DESCRIPTION
## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

## What is the purpose of the pull request

Improvement #3690

The current policy is to take the first one, but the first test is not fixed。This is my debug screenshot.

---
当前策略是取第一个，但是第一个测试下来也是不固定的，这个是我调试截图。
![image](https://user-images.githubusercontent.com/59079269/92440617-5daf6c00-f1df-11ea-8e45-ea2fd2be25a9.png)
![image](https://user-images.githubusercontent.com/59079269/92440630-61db8980-f1df-11ea-8acf-dc2341baee0d.png)

The problem is that on the server, the acquired IP is the external network card IP.External network control is more strict, so it is not a full port through. Therefore, it is recommended to get IP of Intranet card first.So make logical optimizations in your code.

---
遇到的问题是服务器上，获取的ip为外网网卡ip.外网控制比较严格，所以不是全端口打通。所以，建议优先获取内网网卡ip。
所以做出代码中的逻辑优化。