### PR TITLE
[Fix-3707][ui] The batch delete function in the workflow definition and workflow instance pages cannot be canceled if selected

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/pages/projects/pages/definition/pages/list/_source/list.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/projects/pages/definition/pages/list/_source/list.vue
@@ -268,6 +268,12 @@
        * Close the delete layer
        */
       _closeDelete (i) {
+        // close batch
+        if (i < 0) {
+          this.$refs['poptipDeleteAll'].doClose()
+          return
+        }
+        // close one
         this.$refs[`poptip-delete-${i}`][0].doClose()
       },
       /**
@@ -596,8 +602,10 @@
         }).then(res => {
           this._onUpdate()
           this.checkAll = false
+          this.strSelectIds = ''
           this.$message.success(res.msg)
         }).catch(e => {
+          this.strSelectIds = ''
           this.checkAll = false
           this.$message.error(e.msg || '')
         })

--- a/dolphinscheduler-ui/src/js/conf/home/pages/projects/pages/instance/pages/list/_source/list.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/projects/pages/instance/pages/list/_source/list.vue
@@ -344,6 +344,12 @@
        * Close the delete layer
        */
       _closeDelete (i) {
+        // close batch
+        if (i < 0) {
+          this.$refs['poptipDeleteAll'].doClose()
+          return
+        }
+        // close one
         this.$refs[`poptip-delete-${i}`][0].doClose()
       },
       /**
@@ -539,9 +545,11 @@
         }).then(res => {
           this._onUpdate()
           this.checkAll = false
+          this.strDelete = ''
           this.$message.success(res.msg)
         }).catch(e => {
           this.checkAll = false
+          this.strDelete = ''
           this.$message.error(e.msg || '')
         })
       }


### PR DESCRIPTION
## What is the purpose of the pull request
 #3707 
Workflow definition and batch deletion of workflow instance pages
1.Click the batch delete button, the cancel click in the prompt box has no effect
2.After the batch delete is successful, the batch delete button is displayed in a clickable state. Normally, it cannot be clicked. You should delete the records first before clicking the batch delete.

## Brief change log
definition list.vue
instance list.vue

## Verify this pull request
This change added tests and can be verified as follows:
  - *Manually verified the change by testing locally.*

---

![Snipaste_2020-09-09_19-41-24](https://user-images.githubusercontent.com/37063904/92596818-fd045a00-f2d8-11ea-8923-02021b59dd82.png)

![Snipaste_2020-09-09_19-46-30](https://user-images.githubusercontent.com/37063904/92596829-0097e100-f2d9-11ea-8a64-2a070794d287.png)

工作流定义和工作流实例页面批量删除功能
1.点击批量删除按钮，提示框内的取消点击没有效果
2.批量删除成功后，批量删除按钮展示还是可点击状态，正常是不可以点击的，应该先删除记录，才可以点击批量删除。
