### PR TITLE
[Feature][api,dao,sql][backend]add Tag function to ProcessDefinition

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/ProcessDefinitionController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/ProcessDefinitionController.java
@@ -17,23 +17,6 @@
 
 package org.apache.dolphinscheduler.api.controller;
 
-import static org.apache.dolphinscheduler.api.enums.Status.BATCH_COPY_PROCESS_DEFINITION_ERROR;
-import static org.apache.dolphinscheduler.api.enums.Status.BATCH_DELETE_PROCESS_DEFINE_BY_IDS_ERROR;
-import static org.apache.dolphinscheduler.api.enums.Status.BATCH_MOVE_PROCESS_DEFINITION_ERROR;
-import static org.apache.dolphinscheduler.api.enums.Status.CREATE_PROCESS_DEFINITION;
-import static org.apache.dolphinscheduler.api.enums.Status.DELETE_PROCESS_DEFINE_BY_ID_ERROR;
-import static org.apache.dolphinscheduler.api.enums.Status.DELETE_PROCESS_DEFINITION_VERSION_ERROR;
-import static org.apache.dolphinscheduler.api.enums.Status.ENCAPSULATION_TREEVIEW_STRUCTURE_ERROR;
-import static org.apache.dolphinscheduler.api.enums.Status.GET_TASKS_LIST_BY_PROCESS_DEFINITION_ID_ERROR;
-import static org.apache.dolphinscheduler.api.enums.Status.QUERY_DATAIL_OF_PROCESS_DEFINITION_ERROR;
-import static org.apache.dolphinscheduler.api.enums.Status.QUERY_PROCESS_DEFINITION_LIST;
-import static org.apache.dolphinscheduler.api.enums.Status.QUERY_PROCESS_DEFINITION_LIST_PAGING_ERROR;
-import static org.apache.dolphinscheduler.api.enums.Status.QUERY_PROCESS_DEFINITION_VERSIONS_ERROR;
-import static org.apache.dolphinscheduler.api.enums.Status.RELEASE_PROCESS_DEFINITION_ERROR;
-import static org.apache.dolphinscheduler.api.enums.Status.SWITCH_PROCESS_DEFINITION_VERSION_ERROR;
-import static org.apache.dolphinscheduler.api.enums.Status.UPDATE_PROCESS_DEFINITION_ERROR;
-import static org.apache.dolphinscheduler.api.enums.Status.VERIFY_PROCESS_DEFINITION_NAME_UNIQUE_ERROR;
-
 import org.apache.dolphinscheduler.api.enums.Status;
 import org.apache.dolphinscheduler.api.exceptions.ApiException;
 import org.apache.dolphinscheduler.api.service.ProcessDefinitionService;
@@ -73,6 +56,8 @@ import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import springfox.documentation.annotations.ApiIgnore;
+
+import static org.apache.dolphinscheduler.api.enums.Status.*;
 
 
 /**
@@ -651,4 +636,64 @@ public class ProcessDefinitionController extends BaseController {
         return returnDataList(result);
     }
 
+    /**
+     * query process definition all by tag id
+     *
+     * @param loginUser login user
+     * @param tagId tag id
+     * @return process definition list
+     */
+    @ApiOperation(value = "queryProcessDefinitionByTagId", notes = "QUERY_PROCESS_DEFINITION_All_BY_Tag_ID_NOTES")
+    @GetMapping(value = "/queryProcessDefinitionByTagId")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiException(QUERY_PROCESS_DEFINITION_LIST)
+    public Result queryProcessDefinitionByTagId(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                       @RequestParam("tagId") Integer tagId) {
+        logger.info("query process definition list by tag id, login user:{}, project id:{}",
+                loginUser.getUserName(), tagId);
+        Map<String, Object> result = processDefinitionService.queryProcessDefinitionByTagId(tagId);
+        return returnDataList(result);
+    }
+
+    /**
+     * add ProcessDefinition Tags
+     *
+     * @param processId     ProcessDefinition id
+     * @param tagIds tag id array
+     * @return result code
+     */
+    @ApiOperation(value = "addProcessTags", notes = "ADD_PROCESS_TAGS_NOTES")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "processId", value = "PROCESS_ID", dataType = "Int", example = "100"),
+            @ApiImplicitParam(name = "tagIds", value = "TAG_IDS", type = "String")
+    })
+    @PostMapping(value = "/add-process-tags")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiException(ADD_PROCESS_TAGS_ERROR)
+    public Result addProcessDefinitionTags(@RequestParam(value = "processId") int processId,
+            @RequestParam(value = "tagIds") String tagIds) {
+        Map<String, Object> result = processDefinitionService.addProcessDefinitionTags(processId, tagIds);
+        return returnDataList(result);
+    }
+
+    /**
+     * add ProcessDefinition Tags
+     *
+     * @param processId     ProcessDefinition id
+     * @param tagIds tag id array
+     * @return result code
+     */
+    @ApiOperation(value = "deleteProcessTags", notes = "DELETE_PROCESS_TAGS_NOTES")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "processId", value = "PROCESS_ID", dataType = "Int", example = "100"),
+            @ApiImplicitParam(name = "tagIds", value = "TAG_IDS", type = "String")
+    })
+    @PostMapping(value = "/delete-process-tags")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiException(DELETE_PROCESS_TAGS_ERROR)
+    public Result deleteProcessDefinitionTags(@RequestParam(value = "processId") int processId,
+                                           @RequestParam(value = "tagIds") String tagIds) {
+        Map<String, Object> result = processDefinitionService.deleteProcessDefinitionTags(processId, tagIds);
+        return returnDataList(result);
+    }
 }

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/TagController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/TagController.java
@@ -1,0 +1,147 @@
+package org.apache.dolphinscheduler.api.controller;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import org.apache.dolphinscheduler.api.enums.Status;
+import org.apache.dolphinscheduler.api.exceptions.ApiException;
+import org.apache.dolphinscheduler.api.service.TagService;
+import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.common.utils.ParameterUtils;
+import org.apache.dolphinscheduler.dao.entity.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
+
+import java.util.Map;
+
+import static org.apache.dolphinscheduler.api.enums.Status.*;
+
+@Api(tags = "PROCESS_DEFINITION'TAG_TAG")
+@RestController
+@RequestMapping("projects/{projectName}/tag")
+public class TagController extends BaseController {
+
+    private static final Logger logger = LoggerFactory.getLogger(ProcessDefinitionController.class);
+
+    @Autowired
+    private TagService tagService;
+
+    /**
+     * create tag
+     *
+     * @param loginUser login user
+     * @param projectName project name
+     * @param tagname tag name
+     * @return create result code
+     */
+    @ApiOperation(value = "createTag", notes = "CREATE_TAG_NOTES")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "tagName", value = "TAG_NAME", dataType = "String"),
+    })
+    @PostMapping(value = "/create")
+    @ResponseStatus(HttpStatus.CREATED)
+    @ApiException(CREATE_TAG_ERROR)
+    public Result createTag (@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                             @ApiParam(name = "projectName", value = "PROJECT_NAME", required = true) @PathVariable String projectName,
+                             @RequestParam(value = "tagname", required = true) String tagname){
+        logger.info("login user {}, create  tag, project name: {}, tag name: {} ",
+                loginUser.getUserName(), projectName, tagname);
+        Map<String, Object> result = tagService.createTag(loginUser, projectName, tagname);
+        return returnDataList(result);
+    }
+
+    /**
+     * delete tag by id
+     * @param tagId tag id
+     * @param loginUser   login user
+     * @param projectName project name
+     * @return delete result code
+     */
+    @ApiOperation(value = "deleteTag", notes = "DELETE_TAG_NOTES")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "tagId", value = "TAG_ID", required = true, dataType = "Int", example = "100"),
+    })
+    @GetMapping(value = "/delete")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiException(DELETE_TAG_ERROR)
+    public Result deleteTag(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                 @ApiParam(name = "projectName", value = "PROJECT_NAME", required = true) @PathVariable String projectName,
+                                                 @RequestParam(value = "tagId") int tagId) {
+        logger.info("login user {}, update tag, project name: {}, tag id: {}, ",
+                loginUser.getUserName(), projectName, tagId);
+        Map<String, Object> result = tagService.deleteTag(loginUser, projectName, tagId);
+        return returnDataList(result);
+    }
+
+    /**
+     * update Tag
+     *
+     * @param loginUser   login user
+     * @param projectName project name
+     * @param tagId tag id
+     * @param tagName tag name
+     * @return update result code
+     */
+    @ApiOperation(value = "updateTag", notes = "UPDATE_TAG_NOTES")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "tagName", value = "TAG_NAME", required = true, type = "String"),
+            @ApiImplicitParam(name = "tagId", value = "TAG_ID", required = true, dataType = "Int", example = "100"),
+    })
+    @PostMapping(value = "/update")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiException(UPDATE_TAG_ERROR)
+    public Result updateTag(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                          @ApiParam(name = "projectName", value = "PROJECT_NAME", required = true) @PathVariable String projectName,
+                                          @RequestParam(value = "tagName", required = true) String tagName,
+                                          @RequestParam(value = "tagId", required = true) int tagId
+                                          ) {
+
+        logger.info("login user {}, update tag, project name: {}, tag name: {}, ",
+                loginUser.getUserName(), projectName, tagName);
+        Map<String, Object> result = tagService.updateTag(loginUser, projectName, tagId, tagName);
+        return returnDataList(result);
+    }
+
+    /**
+     * admin can view all tags
+     *
+     * @param loginUser login user
+     * @param projectName project name
+     * @param searchVal search value
+     * @param pageSize page size
+     * @param pageNo page number
+     * @return tag list which the login user have permission to see
+     */
+    @ApiOperation(value = "queryTagListPaging", notes = "QUERY_TAG_LIST_PAGING_NOTES")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "pageNo", value = "PAGE_NO", required = true, dataType = "Int", example = "100"),
+            @ApiImplicitParam(name = "searchVal", value = "SEARCH_VAL", required = false, type = "String"),
+            @ApiImplicitParam(name = "pageSize", value = "PAGE_SIZE", required = true, dataType = "Int", example = "100")
+    })
+    @GetMapping(value = "/list-paging")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiException(QUERY_TAG_LIST_PAGING_ERROR)
+    public Result queryTagListPaging(@ApiIgnore @RequestAttribute(value = Constants.SESSION_USER) User loginUser,
+                                                   @ApiParam(name = "projectName", value = "PROJECT_NAME", required = true) @PathVariable String projectName,
+                                                   @RequestParam("pageNo") Integer pageNo,
+                                                   @RequestParam(value = "searchVal", required = false) String searchVal,
+                                                   @RequestParam("pageSize") Integer pageSize) {
+        logger.info("query tag list paging, login user:{}, project name:{}", loginUser.getUserName(), projectName);
+        Map<String, Object> result = checkPageParams(pageNo, pageSize);
+        if (result.get(Constants.STATUS) != Status.SUCCESS) {
+            return returnDataListPaging(result);
+        }
+        searchVal = ParameterUtils.handleEscapes(searchVal);
+        result = tagService.queryTagListPaging(loginUser, projectName, pageSize, pageNo, searchVal);
+        return returnDataListPaging(result);
+    }
+
+
+}

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/enums/Status.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/enums/Status.java
@@ -194,6 +194,16 @@ public enum Status {
     BATCH_MOVE_PROCESS_DEFINITION_ERROR(10160, "batch move process definition error", "移动工作流错误"),
     QUERY_WORKFLOW_LINEAGE_ERROR(10161, "query workflow lineage error", "查询血缘失败"),
 
+    DELETE_TAG_ERROR(10170,"delete tag error","删除标签错误"),
+    TAG_ALREADY_EXISTS(10171,"tag already exists","标签名已存在"),
+    UPDATE_TAG_ERROR(10172,"update tag error","更新标签错误"),
+    CREATE_TAG_ERROR(10173, "create tag error", "新建标签错误"),
+    TAG_NOT_EXIST(10174, "tag not exist","标签不存在"),
+    TAG_NOT_FOUND(10175, "tag not found","标签未找到"),
+    QUERY_TAG_LIST_PAGING_ERROR(10176, "query tag list paging error", "分页查询标签错误"),
+    ADD_PROCESS_TAGS_ERROR(10177, "add processdefinition tags error", "工作流定义添加标签错误"),
+    DELETE_PROCESS_TAGS_ERROR(10178, "delete processdefinition tags error", "工作流定义删除标签错误"),
+
 
     UDF_FUNCTION_NOT_EXIST(20001, "UDF function not found", "UDF函数不存在"),
     UDF_FUNCTION_EXISTS(20002, "UDF function already exists", "UDF函数已存在"),

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ProcessDefinitionService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/ProcessDefinitionService.java
@@ -17,13 +17,20 @@
 
 package org.apache.dolphinscheduler.api.service;
 
+import org.apache.dolphinscheduler.api.enums.Status;
+import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.dao.entity.ProcessData;
+import org.apache.dolphinscheduler.dao.entity.ProcessDefinition;
+import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.User;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletResponse;
 
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -260,5 +267,31 @@ public interface ProcessDefinitionService {
      */
     Map<String, Object> switchProcessDefinitionVersion(User loginUser, String projectName
             , int processDefinitionId, long version);
+
+    /**
+     * add ProcessDefinition Tags
+     *
+     * @param processId ProcessDefinition id
+     * @param tagIds tag id array
+     * @return grant result code
+     */
+    Map<String, Object> addProcessDefinitionTags(int processId, String tagIds);
+
+    /**
+     * delete ProcessDefinition Tags
+     *
+     * @param processId ProcessDefinition id
+     * @param tagIds tag id array
+     * @return grant result code
+     */
+    Map<String, Object> deleteProcessDefinitionTags(int processId, String tagIds);
+
+    /**
+     * query process definition list by tag id
+     *
+     * @param tagId tag id
+     * @return definition list
+     */
+    Map<String, Object> queryProcessDefinitionByTagId(Integer tagId);
 }
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/TagService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/TagService.java
@@ -1,0 +1,210 @@
+package org.apache.dolphinscheduler.api.service;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import org.apache.dolphinscheduler.api.enums.Status;
+import org.apache.dolphinscheduler.api.utils.PageInfo;
+import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.common.enums.UserType;
+import org.apache.dolphinscheduler.dao.entity.Project;
+import org.apache.dolphinscheduler.dao.entity.Tag;
+import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.mapper.ProcessTagMapper;
+import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
+import org.apache.dolphinscheduler.dao.mapper.TagMapper;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+
+/**
+ *
+ * tag service
+ */
+@Service
+public class TagService extends BaseService{
+
+    private static final Logger logger = LoggerFactory.getLogger(TagService.class);
+
+    @Autowired
+    private TagMapper tagMapper;
+
+    @Autowired
+    private ProjectMapper projectMapper;
+
+    @Autowired
+    private ProjectService projectService;
+
+    @Autowired
+    private ProcessTagMapper processTagMapper;
+
+    /**
+     * create tag
+     *
+     * @param loginUser login user
+     * @param projectName project name
+     * @param tagname tag name
+     * @return create result code
+     */
+    public Map<String, Object> createTag(User loginUser, String projectName, String tagname) {
+
+        Map<String, Object> result = new HashMap<>(5);
+
+        //check project auth
+        Project project = projectMapper.queryByName(projectName);
+        Map<String, Object> checkResult = projectService.checkProjectAndAuth(loginUser, project, projectName);
+        Status resultStatus = (Status) checkResult.get(Constants.STATUS);
+        if (resultStatus != Status.SUCCESS) {
+            return checkResult;
+        }
+
+        Tag tag = new Tag();
+
+        tag.setName(tagname);
+        tag.setProjectId(project.getId());
+        tag.setUserId(loginUser.getId());
+        tagMapper.insert(tag);
+
+        result.put(Constants.DATA_LIST, tagMapper.selectById(tag.getId()));
+        putMsg(result, Status.SUCCESS);
+
+        return result;
+    }
+
+    /**
+     * delete tag by id
+     * @param tagId tag id
+     * @param loginUser   login user
+     * @param projectName project name
+     * @return delete result code
+     */
+    public Map<String,Object> deleteTag(User loginUser, String projectName, Integer tagId){
+
+       Map<String, Object> result = new HashMap<>();
+
+        //check project auth
+       Project project = projectMapper.queryByName(projectName);
+       Map<String, Object> checkResult = projectService.checkProjectAndAuth(loginUser, project, projectName);
+       Status resultStatus = (Status) checkResult.get(Constants.STATUS);
+       if (resultStatus != Status.SUCCESS) {
+            return checkResult;
+       }
+
+       Tag tag = tagMapper.selectById(tagId);
+
+        if (tag == null) {
+            putMsg(result, Status.TAG_NOT_EXIST, tag);
+            return result;
+        }
+        // Determine if the login user is the owner of the tag
+        if (loginUser.getId() != tag.getUserId() && loginUser.getUserType() != UserType.ADMIN_USER) {
+            putMsg(result, Status.USER_NO_OPERATION_PERM);
+            return result;
+        }
+
+       int delete = tagMapper.deleteById(tagId);
+        int delete1 = processTagMapper.deleteProcessRelation(0,tagId);
+       if(delete > 0 && delete1 > 0){
+           putMsg(result, Status.SUCCESS);
+       } else {
+           putMsg(result, Status.DELETE_TAG_ERROR);
+       }
+       return result;
+    }
+    /**
+     * update Tag
+     *
+     * @param loginUser   login user
+     * @param projectName project name
+     * @param tagId tag id
+     * @param tagName tag name
+     * @return update result code
+     */
+    public Map<String, Object> updateTag(User loginUser, String projectName, Integer tagId, String tagName) {
+        Map<String, Object> result = new HashMap<>(5);
+
+        Project project = projectMapper.queryByName(projectName);
+        Map<String, Object> checkResult = projectService.checkProjectAndAuth(loginUser, project, projectName);
+        Status resultStatus = (Status) checkResult.get(Constants.STATUS);
+        if (resultStatus != Status.SUCCESS) {
+            return checkResult;
+        }
+
+        Tag tag = tagMapper.selectById(tagId);
+
+        if (tag == null ) {
+            putMsg(result, Status.TAG_NOT_EXIST, tagName);
+            return result;
+        }else{
+            putMsg(result, Status.SUCCESS);
+        }
+
+        tag.setName(tagName);
+        tag.setProjectId(project.getId());
+
+        int update = tagMapper.updateById(tag);
+        if (update > 0) {
+            putMsg(result, Status.SUCCESS);
+        } else {
+            putMsg(result, Status.UPDATE_TAG_ERROR);
+        }
+        return result;
+    }
+
+    /**
+     * admin can view all tags
+     *
+     * @param loginUser login user
+     * @param projectName project name
+     * @param searchVal search value
+     * @param pageSize page size
+     * @param pageNo page number
+     * @return tag list which the login user have permission to see
+     */
+    public Map<String, Object> queryTagListPaging(User loginUser, String projectName, Integer pageSize, Integer pageNo, String searchVal) {
+        Map<String, Object> result = new HashMap<>();
+        PageInfo pageInfo = new PageInfo<Tag>(pageNo, pageSize);
+
+        Page<Tag> page = new Page(pageNo, pageSize);
+
+        Project project = projectMapper.queryByName(projectName);
+
+        Map<String, Object> checkResult = projectService.checkProjectAndAuth(loginUser, project, projectName);
+        Status resultStatus = (Status) checkResult.get(Constants.STATUS);
+        if (resultStatus != Status.SUCCESS) {
+            return checkResult;
+        }
+
+        int userId = loginUser.getUserType() == UserType.ADMIN_USER ? 0 : loginUser.getId();
+        IPage<Tag> tagIPage = tagMapper.queryTagListPaging(page, userId, project.getId(), searchVal);
+
+        pageInfo.setTotalCount((int) tagIPage.getTotal());
+        pageInfo.setLists(tagIPage.getRecords());
+        result.put(Constants.DATA_LIST, pageInfo);
+        putMsg(result, Status.SUCCESS);
+
+        return result;
+    }
+    /**
+     * query tag  by id
+     *
+     * @param tagId tag id
+     * @return tag detail information
+     */
+    public Map<String, Object> queryById(Integer tagId) {
+
+        Map<String, Object> result = new HashMap<>(5);
+        Tag tag = tagMapper.selectById(tagId);
+
+        if (tag != null) {
+            result.put(Constants.DATA_LIST, tag);
+            putMsg(result, Status.SUCCESS);
+        } else {
+            putMsg(result, Status.TAG_NOT_FOUND, tagId);
+        }
+        return result;
+    }
+}

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
@@ -55,19 +55,8 @@ import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.common.utils.StreamUtils;
 import org.apache.dolphinscheduler.common.utils.StringUtils;
 import org.apache.dolphinscheduler.common.utils.TaskParametersUtils;
-import org.apache.dolphinscheduler.dao.entity.ProcessData;
-import org.apache.dolphinscheduler.dao.entity.ProcessDefinition;
-import org.apache.dolphinscheduler.dao.entity.ProcessDefinitionVersion;
-import org.apache.dolphinscheduler.dao.entity.ProcessInstance;
-import org.apache.dolphinscheduler.dao.entity.Project;
-import org.apache.dolphinscheduler.dao.entity.Schedule;
-import org.apache.dolphinscheduler.dao.entity.TaskInstance;
-import org.apache.dolphinscheduler.dao.entity.User;
-import org.apache.dolphinscheduler.dao.mapper.ProcessDefinitionMapper;
-import org.apache.dolphinscheduler.dao.mapper.ProcessInstanceMapper;
-import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
-import org.apache.dolphinscheduler.dao.mapper.ScheduleMapper;
-import org.apache.dolphinscheduler.dao.mapper.TaskInstanceMapper;
+import org.apache.dolphinscheduler.dao.entity.*;
+import org.apache.dolphinscheduler.dao.mapper.*;
 import org.apache.dolphinscheduler.dao.utils.DagHelper;
 import org.apache.dolphinscheduler.service.permission.PermissionCheck;
 import org.apache.dolphinscheduler.service.process.ProcessService;
@@ -144,6 +133,9 @@ public class ProcessDefinitionServiceImpl extends BaseService implements
 
     @Autowired
     private ProcessService processService;
+
+    @Autowired
+    private ProcessTagMapper processTagMapper;
 
     /**
      * create process definition
@@ -1724,5 +1716,94 @@ public class ProcessDefinitionServiceImpl extends BaseService implements
         }
     }
 
+    /**
+     * add ProcessDefinition Tags
+     *
+     * @param processId ProcessDefinition id
+     * @param tagIds tag id array
+     * @return grant result code
+     */
+    @Override
+    @Transactional(rollbackFor = RuntimeException.class)
+    public Map<String, Object> addProcessDefinitionTags(int processId, String tagIds){
+        Map<String, Object> result = new HashMap<>();
+        result.put(Constants.STATUS, false);
+
+        ProcessDefinition processDefinition = processDefineMapper.selectById(processId);
+        if(processDefinition == null){
+            putMsg(result, Status.PROCESS_DEFINE_NOT_EXIST, processId);
+            return result;
+        }
+
+        if (StringUtils.isEmpty(tagIds)) {
+            result.put(Constants.STATUS, Status.SUCCESS);
+            return result;
+        }
+
+        String[] tagIdArr = tagIds.split(",");
+
+        for (String tagId : tagIdArr) {
+
+            ProcessTag processTag = new ProcessTag();
+            processTag.setProcessID(processId);
+            processTag.settagID(Integer.parseInt(tagId));
+            processTagMapper.insert(processTag);
+        }
+
+        putMsg(result, Status.SUCCESS);
+
+        return result;
+    }
+
+    /**
+     * delete ProcessDefinition Tags
+     *
+     * @param processId ProcessDefinition id
+     * @param tagIds tag id array
+     * @return result code
+     */
+    @Override
+    public Map<String, Object> deleteProcessDefinitionTags(int processId, String tagIds){
+        Map<String, Object> result = new HashMap<>();
+        result.put(Constants.STATUS, false);
+
+        ProcessDefinition processDefinition = processDefineMapper.selectById(processId);
+        if(processDefinition == null){
+            putMsg(result, Status.PROCESS_DEFINE_NOT_EXIST, processId);
+            return result;
+        }
+
+        if (StringUtils.isEmpty(tagIds)) {
+            result.put(Constants.STATUS, Status.SUCCESS);
+            return result;
+        }
+
+        String[] tagIdArr = tagIds.split(",");
+
+        for (String tagId : tagIdArr) {
+            processTagMapper.deleteProcessRelation(processId,Integer.parseInt(tagId));
+        }
+
+        putMsg(result, Status.SUCCESS);
+
+        return result;
+    }
+
+    /**
+     * query process definition list
+     *
+     * @param tagId tag id
+     * @return definition list
+     */
+    @Override
+    public Map<String, Object> queryProcessDefinitionByTagId(Integer tagId){
+        HashMap<String, Object> result = new HashMap<>();
+
+        List<ProcessDefinition> resourceList = processDefineMapper.queryAllDefinitionListByTagId(tagId);
+        result.put(Constants.DATA_LIST, resourceList);
+        putMsg(result, Status.SUCCESS);
+
+        return result;
+    }
 }
 

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/ProcessDefinitionControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/ProcessDefinitionControllerTest.java
@@ -346,6 +346,19 @@ public class ProcessDefinitionControllerTest {
     }
 
     @Test
+    public void testQueryProcessDefinitionByTagId() throws Exception {
+        int tagId = 1;
+        Map<String, Object> result = new HashMap<>();
+        putMsg(result, Status.SUCCESS);
+
+        Mockito.when(processDefinitionService.queryProcessDefinitionByTagId(tagId)).thenReturn(result);
+        Result response = processDefinitionController.queryProcessDefinitionByTagId(user,tagId);
+
+        Assert.assertEquals(Status.SUCCESS.getCode(), response.getCode().intValue());
+    }
+
+
+    @Test
     public void testViewTree() throws Exception {
         String projectName = "test";
         int processId = 1;
@@ -446,6 +459,40 @@ public class ProcessDefinitionControllerTest {
                 , projectName
                 , 1
                 , 10);
+
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
+    }
+
+    @Test
+    public void testAddProcessDefinitionTags() {
+        int processId = 22;
+        String tagIds = "3";
+        Map<String, Object> resultMap = new HashMap<>();
+        putMsg(resultMap, Status.SUCCESS);
+        Mockito.when(processDefinitionService.addProcessDefinitionTags(
+                processId,
+                tagIds))
+                .thenReturn(resultMap);
+        Result result = processDefinitionController.addProcessDefinitionTags(
+                processId,
+                tagIds);
+
+        Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
+    }
+
+    @Test
+    public void testDeleteProcessDefinitionTags() {
+        int processId = 22;
+        String tagIds = "3";
+        Map<String, Object> resultMap = new HashMap<>();
+        putMsg(resultMap, Status.SUCCESS);
+        Mockito.when(processDefinitionService.deleteProcessDefinitionTags(
+                processId,
+                tagIds))
+                .thenReturn(resultMap);
+        Result result = processDefinitionController.deleteProcessDefinitionTags(
+                processId,
+                tagIds);
 
         Assert.assertEquals(Status.SUCCESS.getCode(), (int) result.getCode());
     }

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/TagControllerTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/controller/TagControllerTest.java
@@ -1,0 +1,96 @@
+package org.apache.dolphinscheduler.api.controller;
+
+import org.apache.dolphinscheduler.api.enums.Status;
+import org.apache.dolphinscheduler.api.utils.Result;
+import org.apache.dolphinscheduler.common.utils.JSONUtils;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.junit.Assert;
+
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class TagControllerTest extends AbstractControllerTest {
+
+    private static Logger logger = LoggerFactory.getLogger(TagControllerTest.class);
+
+    @Test
+    public void testCreateTag() throws Exception {
+        MultiValueMap<String, String> paramsMap = new LinkedMultiValueMap<>();
+        paramsMap.add("tagName","tag_test1");
+
+        MvcResult mvcResult = mockMvc.perform(post("/projects/{projectName}/tag/create")
+                .header("sessionId", sessionId)
+                .params(paramsMap))
+                .andExpect(status().isCreated())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andReturn();
+        Result result = JSONUtils.parseObject(mvcResult.getResponse().getContentAsString(), Result.class);
+        Assert.assertEquals(Status.SUCCESS.getCode(),result.getCode().intValue());
+        logger.info(mvcResult.getResponse().getContentAsString());
+
+    }
+
+    @Test
+    public void testDeleteTag() throws Exception {
+        MultiValueMap<String, String> paramsMap = new LinkedMultiValueMap<>();
+        paramsMap.add("tagId","18");
+
+        MvcResult mvcResult = mockMvc.perform(get("/projects/{projectName}/tag/delete")
+                .header(SESSION_ID, sessionId)
+                .params(paramsMap))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andReturn();
+
+        Result result = JSONUtils.parseObject(mvcResult.getResponse().getContentAsString(), Result.class);
+        Assert.assertEquals(Status.SUCCESS.getCode(),result.getCode().intValue());
+        logger.info(mvcResult.getResponse().getContentAsString());
+    }
+
+    @Test
+    public void testUpdateTag() throws Exception {
+        MultiValueMap<String, String> paramsMap = new LinkedMultiValueMap<>();
+        paramsMap.add("tagId","18");
+        paramsMap.add("tagName","tag_test_update");
+
+        MvcResult mvcResult = mockMvc.perform(post("/projects/{projectName}/tag/update")
+                .header(SESSION_ID, sessionId)
+                .params(paramsMap))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andReturn();
+
+        Result result = JSONUtils.parseObject(mvcResult.getResponse().getContentAsString(), Result.class);
+        Assert.assertEquals(Status.SUCCESS.getCode(),result.getCode().intValue());
+        logger.info(mvcResult.getResponse().getContentAsString());
+    }
+
+    @Test
+    public void testTagListPaging() throws Exception {
+        MultiValueMap<String, String> paramsMap = new LinkedMultiValueMap<>();
+        paramsMap.add("pageNo","2");
+        paramsMap.add("searchVal","test");
+        paramsMap.add("pageSize","2");
+
+
+        MvcResult mvcResult = mockMvc.perform(get("/projects/{projectName}/tag/list-paging")
+                .header(SESSION_ID, sessionId)
+                .params(paramsMap))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andReturn();
+
+        Result result = JSONUtils.parseObject(mvcResult.getResponse().getContentAsString(), Result.class);
+        Assert.assertEquals(Status.SUCCESS.getCode(),result.getCode().intValue());
+        logger.info(mvcResult.getResponse().getContentAsString());
+    }
+}

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProcessDefinitionServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProcessDefinitionServiceTest.java
@@ -72,6 +72,8 @@ import org.springframework.web.multipart.MultipartFile;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 
+import static org.mockito.Mockito.when;
+
 @RunWith(MockitoJUnitRunner.class)
 public class ProcessDefinitionServiceTest {
 
@@ -705,6 +707,18 @@ public class ProcessDefinitionServiceTest {
     }
 
     @Test
+    public void testQueryProcessDefinitionByTagId() {
+        int tagId = 1;
+        ProcessDefinition processDefinition = getProcessDefinition();
+        processDefinition.setProcessDefinitionJson(SHELL_JSON);
+        List<ProcessDefinition> processDefinitionList = new ArrayList<>();
+        processDefinitionList.add(processDefinition);
+        Mockito.when(processDefineMapper.queryAllDefinitionListByTagId(tagId)).thenReturn(processDefinitionList);
+        Map<String, Object> successRes = processDefinitionService.queryProcessDefinitionByTagId(tagId);
+        Assert.assertEquals(Status.SUCCESS, successRes.get(Constants.STATUS));
+    }
+
+    @Test
     public void testViewTree() throws Exception {
         //process definition not exist
         ProcessDefinition processDefinition = getProcessDefinition();
@@ -983,6 +997,36 @@ public class ProcessDefinitionServiceTest {
 
         processDefinitionService.batchExportProcessDefinitionByIds(
                 loginUser, projectName, "1", null);
+    }
+
+    @Test
+    public void testAddProcessDefinitionTags(){
+
+        when(processDefineMapper.selectById(46)).thenReturn(getProcessDefinition());
+        User loginUser = new User();
+        String  tagIds= "10,12";
+
+        //processDefine not exist
+        Map<String, Object> result = processDefinitionService.addProcessDefinitionTags(47, tagIds);
+        Assert.assertEquals(Status.PROCESS_DEFINE_NOT_EXIST, result.get(Constants.STATUS));
+        //success
+        result = processDefinitionService.addProcessDefinitionTags(46, tagIds);
+        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+    }
+
+    @Test
+    public void testDeleteProcessDefinitionTags(){
+
+        when(processDefineMapper.selectById(46)).thenReturn(getProcessDefinition());
+        User loginUser = new User();
+        String  tagIds= "10,12";
+
+        //processDefine not exist
+        Map<String, Object> result = processDefinitionService.deleteProcessDefinitionTags(47, tagIds);
+        Assert.assertEquals(Status.PROCESS_DEFINE_NOT_EXIST, result.get(Constants.STATUS));
+        //success
+        result = processDefinitionService.deleteProcessDefinitionTags(46, tagIds);
+        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
     }
 
     /**

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TagServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/TagServiceTest.java
@@ -1,0 +1,247 @@
+package org.apache.dolphinscheduler.api.service;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import org.apache.dolphinscheduler.api.ApiApplicationServer;
+import org.apache.dolphinscheduler.api.enums.Status;
+import org.apache.dolphinscheduler.api.service.impl.ProcessDefinitionServiceImpl;
+import org.apache.dolphinscheduler.api.service.impl.ProjectServiceImpl;
+import org.apache.dolphinscheduler.common.Constants;
+import org.apache.dolphinscheduler.common.enums.UserType;
+import org.apache.dolphinscheduler.dao.entity.ProcessDefinition;
+import org.apache.dolphinscheduler.dao.entity.Project;
+import org.apache.dolphinscheduler.dao.entity.Tag;
+import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.mapper.ProcessDefinitionMapper;
+import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
+import org.apache.dolphinscheduler.dao.mapper.TagMapper;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.inject.Inject;
+
+
+import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+@SpringBootTest(classes = ApiApplicationServer.class)
+public class TagServiceTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(TagServiceTest.class);
+
+    @InjectMocks
+    TagService tagService;
+
+    @Mock
+    TagMapper tagMapper;
+
+    @Mock
+    private ProjectServiceImpl projectService;
+
+    @Mock
+    private ProjectMapper projectMapper;
+
+    @Mock
+    private ProcessDefinitionServiceImpl processDefinitionService;
+
+    @Mock
+    private ProcessDefinitionMapper processDefineMapper;
+
+    private String userName = "TagServiceTest";
+
+    private String tagName = "TagServiceTest";
+
+    private String projectName = "TagServiceTest";
+
+    @Test
+    public void createTag() {
+
+        String projectName = "project_test1";
+        Mockito.when(projectMapper.queryByName(projectName)).thenReturn(getProject(projectName));
+
+        Project project = getProject(projectName);
+        User loginUser = new User();
+        loginUser.setId(-1);
+        loginUser.setUserType(UserType.GENERAL_USER);
+
+        //project check auth fail
+        Map<String, Object> result = new HashMap<>();
+        putMsg(result, Status.PROJECT_NOT_FOUNT, projectName);
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(result);
+        Map<String, Object> map = tagService.createTag(loginUser, "project_test1", "tag_test");
+        Assert.assertEquals(Status.PROJECT_NOT_FOUNT, map.get(Constants.STATUS));
+
+        //success
+        Mockito.when(tagMapper.selectById(46)).thenReturn(getTag());
+        Map<String, Object> deleteSuccess = tagService.createTag(loginUser, "project_test1", tagName);
+        Assert.assertEquals(Status.SUCCESS, deleteSuccess.get(Constants.STATUS));
+
+    }
+
+    @Test
+    public void deleteTag() {
+        String projectName = "project_test1";
+        Mockito.when(projectMapper.queryByName(projectName)).thenReturn(getProject(projectName));
+
+        Project project = getProject(projectName);
+        User loginUser = new User();
+        loginUser.setId(-1);
+        loginUser.setUserType(UserType.GENERAL_USER);
+
+        //project check auth fail
+        Map<String, Object> result = new HashMap<>();
+        putMsg(result, Status.PROJECT_NOT_FOUNT, projectName);
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(result);
+        Map<String, Object> map = tagService.deleteTag(loginUser, "project_test1", 6);
+        Assert.assertEquals(Status.PROJECT_NOT_FOUNT, map.get(Constants.STATUS));
+
+        //project check auth success, tag not exist
+        putMsg(result, Status.SUCCESS, projectName);
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(result);
+        Mockito.when(processDefineMapper.selectById(1)).thenReturn(null);
+        Map<String, Object> instanceNotexitRes = tagService.deleteTag(loginUser,
+                "project_test1", 1);
+        Assert.assertEquals(Status.TAG_NOT_EXIST, instanceNotexitRes.get(Constants.STATUS));
+
+        Tag tag = getTag();
+        //user no auth
+        loginUser.setUserType(UserType.GENERAL_USER);
+        Mockito.when(tagMapper.selectById(46)).thenReturn(tag);
+        Map<String, Object> userNoAuthRes = tagService.deleteTag(loginUser,
+                "project_test1", 46);
+        Assert.assertEquals(Status.USER_NO_OPERATION_PERM, userNoAuthRes.get(Constants.STATUS));
+        //success
+        Mockito.when(tagMapper.deleteById(46)).thenReturn(1);
+        Map<String, Object> deleteSuccess = tagService.deleteTag(loginUser,
+                "project_test1", 46);
+        Assert.assertEquals(Status.SUCCESS, deleteSuccess.get(Constants.STATUS));
+    }
+
+    @Test
+    public void updateTag() {
+        User loginUser = new User();
+        loginUser.setId(1);
+        loginUser.setUserType(UserType.ADMIN_USER);
+
+        Map<String, Object> result = new HashMap<>();
+        putMsg(result, Status.SUCCESS);
+
+        String projectName = "project_test1";
+        Project project = getProject(projectName);
+
+        Tag tag = getTag();
+
+        Mockito.when(projectMapper.queryByName(projectName)).thenReturn(getProject(projectName));
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(result);
+
+        Map<String, Object> updateResult = tagService.updateTag(loginUser,projectName,tag.getId(),"tag_test");
+        Assert.assertEquals(Status.SUCCESS, updateResult.get(Constants.STATUS));
+    }
+
+    @Test
+    public void queryTagListPaging() {
+        String projectName = "project_test1";
+        Mockito.when(projectMapper.queryByName(projectName)).thenReturn(getProject(projectName));
+
+        Project project = getProject(projectName);
+
+        User loginUser = new User();
+        loginUser.setId(-1);
+        loginUser.setUserType(UserType.GENERAL_USER);
+
+        Map<String, Object> result = new HashMap<>();
+        putMsg(result, Status.PROJECT_NOT_FOUNT, projectName);
+
+        //project not found
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(result);
+        Map<String, Object> map = tagService.queryTagListPaging(loginUser, "project_test1", 1, 5, "" );
+        Assert.assertEquals(Status.PROJECT_NOT_FOUNT, map.get(Constants.STATUS));
+
+        putMsg(result, Status.SUCCESS, projectName);
+        loginUser.setId(1);
+        Mockito.when(projectService.checkProjectAndAuth(loginUser, project, projectName)).thenReturn(result);
+        Page<ProcessDefinition> page = new Page<>(1, 10);
+        page.setTotal(30);
+        Mockito.when(tagMapper.queryTagListPaging(
+                Mockito.any(IPage.class)
+                , Mockito.eq(loginUser.getId())
+                , Mockito.eq(project.getId())
+                , Mockito.eq(""))).thenReturn(page);
+
+        Map<String, Object> map1 = tagService.queryTagListPaging(loginUser, projectName, 1, 10, "" );
+
+        Assert.assertEquals(Status.SUCCESS, map1.get(Constants.STATUS));
+    }
+
+    @Test
+    public void queryById() {
+        //not exist
+        Map<String, Object> result = tagService.queryById(Integer.MAX_VALUE);
+        Assert.assertEquals(Status.TAG_NOT_FOUND, result.get(Constants.STATUS));
+        logger.info(result.toString());
+
+        //success
+        Mockito.when(tagMapper.selectById(46)).thenReturn(getTag());
+        result = tagService.queryById(46);
+        logger.info(result.toString());
+        Assert.assertEquals(Status.SUCCESS, result.get(Constants.STATUS));
+    }
+
+    /**
+     * create admin user
+     * @return
+     */
+    private User getLoginUser(){
+
+        User loginUser = new User();
+        loginUser.setUserType(UserType.GENERAL_USER);
+        loginUser.setUserName(userName);
+        loginUser.setId(1);
+        return  loginUser;
+
+    }
+
+    /**
+     * get mock Project
+     *
+     * @param projectName projectName
+     * @return Project
+     */
+    private Project getProject(String projectName) {
+        Project project = new Project();
+        project.setId(1);
+        project.setName(projectName);
+        project.setUserId(1);
+        return project;
+    }
+
+    private Tag getTag(){
+        Tag tag = new Tag();
+        tag.setId(46);
+        tag.setName(tagName);
+        tag.setUserId(1);
+        tag.setProjectId(1);
+        return tag;
+    }
+
+    private void putMsg(Map<String, Object> result, Status status, Object... statusParams) {
+        result.put(Constants.STATUS, status);
+        if (statusParams != null && statusParams.length > 0) {
+            result.put(Constants.MSG, MessageFormat.format(status.getMsg(), statusParams));
+        } else {
+            result.put(Constants.MSG, status.getMsg());
+        }
+    }
+}

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/entity/ProcessTag.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/entity/ProcessTag.java
@@ -1,0 +1,57 @@
+package org.apache.dolphinscheduler.dao.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+
+/**
+ * ProcessTag
+ */
+@TableName("t_ds_relation_process_tag")
+public class ProcessTag {
+
+    /**
+     * id
+     */
+    @TableId(value="id", type= IdType.AUTO)
+    private int id;
+
+    @TableField("process_id")
+    private int processID;
+
+    @TableField("tag_id")
+    private int tagID;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public int gettagID() {
+        return tagID;
+    }
+
+    public void settagID(int userId) {
+        this.tagID = tagID;
+    }
+
+    public int getProcessID() {
+        return processID;
+    }
+
+    public void setProcessID(int processID) {
+        this.processID = processID;
+    }
+    @Override
+    public String toString() {
+        return "ProcessTag{" +
+                "id=" + id +
+                ", processID=" + processID +
+                ", tagID=" + tagID +
+                '}';
+    }
+}

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/entity/Tag.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/entity/Tag.java
@@ -1,0 +1,85 @@
+package org.apache.dolphinscheduler.dao.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+
+
+import java.util.Date;
+
+/**
+ * Tag
+ */
+@TableName("t_ds_process_definiton_tags")
+public class Tag {
+
+    /**
+     * id
+     */
+    @TableId(value="id", type= IdType.AUTO)
+    private int id;
+
+    /**
+     * TagName
+     */
+    private String name;
+
+    /**
+     * project id
+     */
+    private int projectId;
+
+    /**
+     * tag user id
+     */
+    private int userId;
+
+
+
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(int projectId) {
+        this.projectId = projectId;
+    }
+
+    public int getUserId() {
+        return userId;
+    }
+
+    public void setUserId(int userId) {
+        this.userId = userId;
+    }
+
+
+
+
+    @Override
+    public String toString() {
+        return "Tag{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", projectId=" + projectId +
+                ", userId=" + userId +
+                '}';
+    }
+}

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/ProcessDefinitionMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/ProcessDefinitionMapper.java
@@ -129,4 +129,12 @@ public interface ProcessDefinitionMapper extends BaseMapper<ProcessDefinition> {
      * @param version version
      */
     void updateVersionByProcessDefinitionId(@Param("processDefinitionId") int processDefinitionId, @Param("version") long version);
+
+    /**
+     * query all process definition list by tag id
+     *
+     * @param tagId tagId
+     * @return process definition list
+     */
+    List<ProcessDefinition> queryAllDefinitionListByTagId(@Param("tagId") int tagId);
 }

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/ProcessTagMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/ProcessTagMapper.java
@@ -1,0 +1,18 @@
+package org.apache.dolphinscheduler.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.dolphinscheduler.dao.entity.ProcessTag;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+public interface ProcessTagMapper extends BaseMapper<ProcessTag> {
+    /**
+     * delte process tag relation
+     * @param processID processId
+     * @param tagID tagId
+     * @return delete result
+     */
+    int deleteProcessRelation(@Param("processID") int processID,
+                              @Param("tagID") int tagID);
+}

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/TagMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/TagMapper.java
@@ -1,0 +1,31 @@
+package org.apache.dolphinscheduler.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import org.apache.dolphinscheduler.dao.entity.Tag;
+import org.apache.ibatis.annotations.Param;
+
+
+
+public interface TagMapper extends BaseMapper<Tag> {
+
+    /**
+     * query tag by name
+     * @param tagName tagName
+     * @return tag
+     */
+    Tag queryByName(@Param("tagName")String tagName);
+
+    /**
+     * tag page
+     * @param page page
+     * @param userId userId
+     * @param projectId projectId
+     * @param searchName searchName
+     * @return tag Ipage
+     */
+    IPage<Tag> queryTagListPaging(IPage<Tag> page,
+                                          @Param("userId") int userId,
+                                          @Param("projectId") int projectId,
+                                          @Param("searchName") String searchName);
+}

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessDefinitionMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessDefinitionMapper.xml
@@ -51,6 +51,14 @@
         where project_id = #{projectId}
         order by create_time desc
     </select>
+    <select id="queryAllDefinitionListByTagId" resultType="org.apache.dolphinscheduler.dao.entity.ProcessDefinition">
+        select pd.*
+        from t_ds_process_definition pd
+        left join t_ds_relation_process_tag pt on pd.id = pt.process_id
+        left join t_ds_process_definiton_tags ta on ta.id = pt.tag_id
+        where pt.tag_id = #{tagId}
+        order by create_time desc
+    </select>
     <select id="queryDefinitionListByTenant" resultType="org.apache.dolphinscheduler.dao.entity.ProcessDefinition">
         select *
         from t_ds_process_definition

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessTag.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessTag.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+<mapper namespace="org.apache.dolphinscheduler.dao.mapper.ProcessTagMapper">
+    <delete id="deleteProcessRelation">
+        delete from t_ds_relation_process_tag
+        where 1=1
+        and tag_id = #{tagID}
+        <if test="processID != 0 ">
+            and process_id = #{processID}
+        </if>
+    </delete>
+
+</mapper>

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TagMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TagMapper.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+<mapper namespace="org.apache.dolphinscheduler.dao.mapper.TagMapper">
+    <select id="queryByName" resultType="org.apache.dolphinscheduler.dao.entity.Tag">
+        select t.*,u.user_name,p.name as project_name
+        from t_ds_process_definiton_tags t
+        JOIN t_ds_user u ON t.user_id = u.id
+        JOIN t_ds_project p ON t.project_id = p.id
+        WHERE t.name = #{tagName}
+        limit 1
+    </select>
+    <select id="queryTagListPaging" resultType="org.apache.dolphinscheduler.dao.entity.Tag">
+        select t.id,t.name,COUNT (t.id) as processcount
+        from t_ds_process_definiton_tags t
+        left join t_ds_relation_process_tag pt ON t.id = pt.tag_id
+        left join t_ds_process_definition d ON d.id = pt.process_id
+        where t.project_id = #{projectId}
+        <if test=" searchVal != null and searchVal != ''">
+            and t.name like concat('%', #{searchVal}, '%')
+        </if>
+        <if test=" userId != 0">
+        and t.user_id = #{userId}
+        </if>
+        
+    </select>
+</mapper>

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/ProcessDefinitionMapperTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/ProcessDefinitionMapperTest.java
@@ -19,12 +19,7 @@ package org.apache.dolphinscheduler.dao.mapper;
 
 import org.apache.dolphinscheduler.common.enums.ReleaseState;
 import org.apache.dolphinscheduler.common.enums.UserType;
-import org.apache.dolphinscheduler.dao.entity.DefinitionGroupByUser;
-import org.apache.dolphinscheduler.dao.entity.ProcessDefinition;
-import org.apache.dolphinscheduler.dao.entity.Project;
-import org.apache.dolphinscheduler.dao.entity.Queue;
-import org.apache.dolphinscheduler.dao.entity.Tenant;
-import org.apache.dolphinscheduler.dao.entity.User;
+import org.apache.dolphinscheduler.dao.entity.*;
 
 import java.util.Date;
 import java.util.List;
@@ -63,6 +58,12 @@ public class ProcessDefinitionMapperTest {
 
     @Autowired
     ProjectMapper projectMapper;
+
+    @Autowired
+    TagMapper tagMapper;
+
+    @Autowired
+    ProcessTagMapper processTagMapper;
 
     /**
      * insert
@@ -196,6 +197,27 @@ public class ProcessDefinitionMapperTest {
     public void testQueryAllDefinitionList() {
         ProcessDefinition processDefinition = insertOne();
         List<ProcessDefinition> processDefinitionIPage = processDefinitionMapper.queryAllDefinitionList(1010);
+        Assert.assertNotEquals(processDefinitionIPage.size(), 0);
+    }
+
+    /**
+     * test query all process definition by tag id
+     */
+    @Test
+    public void testQueryAllDefinitionListByTagId() {
+        ProcessDefinition processDefinition = insertOne();
+        Tag tag = new Tag();
+        tag.setName("ut tag");
+        tag.setUserId(111);
+        tag.setProjectId(1010);
+        tagMapper.insert(tag);
+
+        ProcessTag processTag = new ProcessTag();
+        processTag.setProcessID(processDefinition.getId());
+        processTag.settagID(tag.getId());
+        processTagMapper.insert(processTag);
+
+        List<ProcessDefinition> processDefinitionIPage = processDefinitionMapper.queryAllDefinitionListByTagId(tag.getId());
         Assert.assertNotEquals(processDefinitionIPage.size(), 0);
     }
 

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/ProcessTagMapperTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/ProcessTagMapperTest.java
@@ -1,0 +1,75 @@
+package org.apache.dolphinscheduler.dao.mapper;
+
+import org.apache.dolphinscheduler.dao.entity.ProcessTag;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@Transactional
+@Rollback(true)
+public class ProcessTagMapperTest {
+
+    @Autowired
+    ProcessTagMapper processTagMapper;
+
+    /**
+     * insert
+     * @return ProcessTag
+     */
+    private ProcessTag inserOne(){
+        //insertone
+        ProcessTag processTag = new ProcessTag();
+        processTag.setProcessID(1001);
+        processTag.settagID(110);
+        processTagMapper.insert(processTag);
+        return processTag;
+    }
+    /**
+     * test update
+     */
+    @Test
+    public void testUpdate(){
+        //insertOne
+        ProcessTag processTag = inserOne();
+        int update = processTagMapper.updateById(processTag);
+        Assert.assertEquals(update, 1);
+    }
+
+    /**
+     * test delete
+     */
+    @Test
+    public void testDelete(){
+        ProcessTag processTag = inserOne();
+        int delete = processTagMapper.deleteById(processTag.getId());
+        Assert.assertEquals(delete, 1);
+    }
+
+    /**
+     * test query
+     */
+    @Test
+    public void testQuery() {
+        ProcessTag processTag = inserOne();
+        //query
+        List<ProcessTag> processTags = processTagMapper.selectList(null);
+        Assert.assertNotEquals(processTags .size(), 0);
+    }
+    @Test
+    public void deleteProcessRelation() {
+        ProcessTag processTag = inserOne();
+        int delete = processTagMapper.deleteProcessRelation(processTag.getProcessID(),processTag.gettagID());
+        assertThat(delete,greaterThanOrEqualTo(1));
+    }
+}

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/TagMapperTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/TagMapperTest.java
@@ -1,0 +1,109 @@
+package org.apache.dolphinscheduler.dao.mapper;
+
+
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import org.apache.dolphinscheduler.dao.entity.Project;
+import org.apache.dolphinscheduler.dao.entity.Tag;
+import org.apache.dolphinscheduler.dao.entity.User;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@Transactional
+@Rollback(true)
+public class TagMapperTest {
+
+    @Autowired
+    TagMapper tagMapper;
+
+    @Autowired
+    UserMapper userMapper;
+
+    @Autowired
+    ProjectMapper projectMapper;
+
+    /**
+     * insert
+     * @return Tag
+     */
+    private Tag insertOne(){
+        //insertOne
+        Tag tag = new Tag();
+        tag.setName("ut tag");
+        tag.setUserId(111);
+        tag.setProjectId(1010);
+        tagMapper.insert(tag);
+        return tag;
+    }
+    /**
+     * test update
+     */
+    @Test
+    public void testUpdate(){
+        //insertOne
+        Tag tag = insertOne();
+        //update
+        int update = tagMapper.updateById(tag);
+        Assert.assertEquals(update, 1);
+    }
+
+    /**
+     * test delete
+     */
+    @Test
+    public void testDelete(){
+        Tag tag = insertOne();
+        int delete = tagMapper.deleteById(tag.getId());
+        Assert.assertEquals(delete, 1);
+    }
+
+    /**
+     * test query
+     */
+    @Test
+    public void testQuery() {
+        Tag tag = insertOne();
+        //query
+        List<Tag> tags = tagMapper.selectList(null);
+        Assert.assertNotEquals(tags .size(), 0);
+    }
+    @Test
+    public void queryByName() {
+        User user = new User();
+        user.setUserName("ut user");
+        userMapper.insert(user);
+
+        Project project = new Project();
+        project.setName("ut project");
+        project.setUserId(user.getId());
+        projectMapper.insert(project);
+
+        Tag tag = insertOne();
+        tag.setProjectId(project.getId());
+        tag.setUserId(user.getId());
+        tagMapper.updateById(tag);
+        Tag tag1 = tagMapper.queryByName(tag.getName());
+        Assert.assertNotEquals(tag1,null);
+    }
+
+    @Test
+    public void queryTagListPaging() {
+        Tag tag = insertOne();
+        Page<Tag> page = new Page(1,3);
+        IPage<Tag> tagIPage = tagMapper.queryTagListPaging(page,111,1101,null);
+        Assert.assertNotEquals(tagIPage.getTotal(), 0);
+    }
+}

--- a/sql/dolphinscheduler_mysql.sql
+++ b/sql/dolphinscheduler_mysql.sql
@@ -424,6 +424,23 @@ CREATE TABLE `t_ds_process_definition` (
 -- ----------------------------
 
 -- ----------------------------
+-- Table structure for t_ds_process_definition_tags
+-- ----------------------------
+DROP TABLE IF EXISTS `t_ds_process_definiton_tags`;
+CREATE TABLE `t_ds_process_definiton_tags` (
+  `id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'key',
+  `name` varchar(255) DEFAULT NULL COMMENT 'process definition tag name',
+  `project_id` int(11) DEFAULT NULL COMMENT 'project id',
+  `user_id` int(11) DEFAULT NULL COMMENT 'process definition tag creator id',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `process_definition_tag_unique` (`name`,`project_id`),
+  KEY `process_definition_tags_index` (`project_id`,`id`) USING BTREE
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+-- ----------------------------
+-- Records of t_ds_process_definition_tags
+-- ----------------------------
+
+-- ----------------------------
 -- Table structure for t_ds_process_definition_version
 -- ----------------------------
 DROP TABLE IF EXISTS `t_ds_process_definition_version`;
@@ -550,6 +567,21 @@ CREATE TABLE `t_ds_relation_datasource_user` (
 
 -- ----------------------------
 -- Records of t_ds_relation_datasource_user
+-- ----------------------------
+
+
+-- ----------------------------
+-- Table structure for t_ds_relation_process_tag
+-- ----------------------------
+DROP TABLE IF EXISTS `t_ds_relation_process_tag`;
+CREATE TABLE `t_ds_relation_process_tag` (
+  `id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'key',
+  `process_id` int(11) NOT NULL COMMENT 'process id',
+  `tag_id` int(11) DEFAULT NULL COMMENT 'tag id',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+-- ----------------------------
+-- Records of t_ds_relation_process_tag
 -- ----------------------------
 
 -- ----------------------------

--- a/sql/upgrade/1.3.3_schema/mysql/dolphinscheduler_ddl.sql
+++ b/sql/upgrade/1.3.3_schema/mysql/dolphinscheduler_ddl.sql
@@ -87,3 +87,44 @@ delimiter ;
 CALL ct_dolphin_T_t_ds_process_definition_version;
 DROP PROCEDURE ct_dolphin_T_t_ds_process_definition_version;
 
+-- uc_dolphin_T_t_ds_process_definition_A_process_tag
+drop PROCEDURE if EXISTS ct_dolphin_T_t_ds_relation_process_tag;
+delimiter d//
+CREATE PROCEDURE ct_dolphin_T_t_ds_relation_process_tag()
+BEGIN
+    CREATE TABLE `t_ds_relation_process_tag` (
+                                              `id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'key',
+                                              `process_id` int(11) NOT NULL COMMENT 'process id',
+                                              `tag_id` int(11) DEFAULT NULL COMMENT 'tag id',
+                                              PRIMARY KEY (`id`)
+    ) ENGINE=InnoDB AUTO_INCREMENT=84 DEFAULT CHARSET=utf8;
+END;
+
+d//
+
+delimiter ;
+CALL ct_dolphin_T_t_ds_relation_process_tag;
+DROP PROCEDURE ct_dolphin_T_t_ds_relation_process_tag;
+
+-- uc_dolphin_T_t_ds_process_definition_A_tag
+drop PROCEDURE if EXISTS ct_dolphin_T_t_ds_process_definiton_tags;
+delimiter d//
+CREATE PROCEDURE ct_dolphin_T_t_ds_process_definiton_tags()
+BEGIN
+    CREATE TABLE `t_ds_process_definiton_tags` (
+                                                 `id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'key',
+                                                 `name` varchar(255) DEFAULT NULL COMMENT 'process definition tag name',
+                                                 `project_id` int(11) DEFAULT NULL COMMENT 'project id',
+                                                 `user_id` int(11) DEFAULT NULL COMMENT 'process definition tag creator id',
+                                                  PRIMARY KEY (`id`),
+                                                  UNIQUE KEY `process_definition_tag_unique` (`name`,`project_id`),
+                                                  KEY `process_definition_tags_index` (`project_id`,`id`) USING BTREE
+    ) ENGINE=InnoDB AUTO_INCREMENT=84 DEFAULT CHARSET=utf8;
+END;
+
+d//
+
+delimiter ;
+CALL ct_dolphin_T_t_ds_process_definiton_tags;
+DROP PROCEDURE ct_dolphin_T_t_ds_process_definiton_tags;
+


### PR DESCRIPTION
## What is the purpose of the pull request

* This pull request add Tag function to ProcessDefinition. Write the Tag's controller, sercive, mapper code, so that  simple CRUD can be completed independently. And you can add and delete Tags for ProcessDefiniton, and find ProcessDefinitions based on Tag.

## Brief change log

  - create `t_ds_process_definiton_tags` table to store Tag information like `tagname` `project_id` `user_id`. 
     create `t_ds_relation_process_tag` table to store the relationship between Tag and ProcessDefinition.

  - add the `Tag` `ProcessTag` classes, the  `controller` `sercive` `mapper` `xml` code for Tag and ProcessTag. In order to realize the verification authority of the `Tag`, the `project_id` `user_id` field is added to `t_ds_process_definiton_tags` table, imitating the similar function code defined in ProcessDefinition.

  - `addProcessDefinitionTags` `deleteProcessDefinitionTags` `queryProcessDefinitionByTagId` the three new methods have been added in `ProcessDefinitionService` to realize ProcessDefinition add, delete tags, and query ProcessDefinitions based on tag

## Verify this pull request

This change added tests and can be verified as follows:

  - *Added Tag-mapper, sercive, controller tests*
  - *Added ProcessTag-mapper tests.*
  - *Added ProcessDefinition-sercive, controller tests for `testAddProcessDefinitionTags` `testDeleteProcessDefinitionTags` `testQueryProcessDefinitionByTagId`*

---
##拉取请求的目的

*此拉取请求将Tag的功能添加到ProcessDefinition。编写Tag的controller, sercive, mapper代码，以便可以独立完成简单的CRUD。您可以添加和删除ProcessDefiniton的标签，并根据标签查找ProcessDefinitions。

##简要更改日志

  -创建“ t_ds_process_definiton_tags”表以存储标签信息，例如“ tagname”，“ project_id”，“ user_id”。
    创建`t_ds_relation_process_tag`表来存储Tag和ProcessDefinition之间的关系。

  -添加`Tag``ProcessTag`类，Tag和ProcessTag的`controller`sercive`mapper`xml`代码。为了实现“Tag”的验证权限，将“ project_id”和“ user_id”字段添加到“ t_ds_process_definiton_tags”表中，这部分模仿ProcessDefinition中的类似的功能代码。

  -`addProcessDefinitionTags``deleteProcessDefinitionTags``queryProcessDefinitionByTagId`在`ProcessDefinitionService`中添加了三个新方法，以实现ProcessDefinition添加，删除Tag以及基于Tag查询ProcessDefinition的功能

##验证此拉取请求

此更改增加了测试，可以进行如下验证：

  -*添加了Tag-mapper, sercive, controller层的测试*
  -*添加了ProcessTag-mapper层的测试。*
  -*添加了`testAddProcessDefinitionTags``testDeleteProcessDefinitionTags``testQueryProcessDefinitionByTagId`在ProcessDefinition-sercive, controller层的测试*

