### PR TITLE
[Feature-3633][server,common] Let dependent nodes wait for a while before the pre-dependency starts

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/task/TaskTimeoutParameter.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/task/TaskTimeoutParameter.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.dolphinscheduler.common.task;
 
 import org.apache.dolphinscheduler.common.enums.TaskTimeoutStrategy;
@@ -32,6 +33,11 @@ public class TaskTimeoutParameter {
      * task timeout interval
      */
     private int interval;
+
+    /**
+     * The interval for checking whether an event has occurred.
+     */
+    private int checkInterval;
 
     public boolean getEnable() {
         return enable;
@@ -57,6 +63,14 @@ public class TaskTimeoutParameter {
         this.interval = interval;
     }
 
+    public int getCheckInterval() {
+        return checkInterval;
+    }
+
+    public void setCheckInterval(int checkInterval) {
+        this.checkInterval = checkInterval;
+    }
+
     public TaskTimeoutParameter() {
     }
 
@@ -70,12 +84,20 @@ public class TaskTimeoutParameter {
         this.interval = interval;
     }
 
+    public TaskTimeoutParameter(boolean enable, TaskTimeoutStrategy strategy, int interval, int checkInterval) {
+        this.enable = enable;
+        this.strategy = strategy;
+        this.interval = interval;
+        this.checkInterval = checkInterval;
+    }
+
     @Override
     public String toString() {
-        return "TaskTimeoutParameter{" +
-                "enable=" + enable +
-                ", strategy=" + strategy +
-                ", interval=" + interval +
-                '}';
+        return "TaskTimeoutParameter{"
+                + "enable=" + enable
+                + ", strategy=" + strategy
+                + ", interval=" + interval
+                + ", checkInterval=" + checkInterval
+                + '}';
     }
 }

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/model/TaskNodeTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/model/TaskNodeTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.common.model;
+
+import org.apache.dolphinscheduler.common.task.TaskTimeoutParameter;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author wang
+ */
+public class TaskNodeTest {
+
+    @Test
+    public void testGetTaskTimeoutParameter_1() {
+        TaskNode taskNode = new TaskNode();
+        taskNode.setTimeout("{\"strategy\":\"FAILED\",\"interval\":3,\"enable\":true,\"checkInterval\":1}");
+        TaskTimeoutParameter taskTimeoutParameter = taskNode.getTaskTimeoutParameter();
+        Assert.assertTrue(taskTimeoutParameter.getEnable());
+    }
+
+    @Test
+    public void testGetTaskTimeoutParameter_2() {
+        TaskNode taskNode = new TaskNode();
+        taskNode.setTimeout(null);
+        TaskTimeoutParameter taskTimeoutParameter = taskNode.getTaskTimeoutParameter();
+        Assert.assertFalse(taskTimeoutParameter.getEnable());
+    }
+
+}

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/ConditionsTaskExecThread.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/ConditionsTaskExecThread.java
@@ -23,19 +23,19 @@ import org.apache.dolphinscheduler.common.model.DependentItem;
 import org.apache.dolphinscheduler.common.model.DependentTaskModel;
 import org.apache.dolphinscheduler.common.task.dependent.DependentParameters;
 import org.apache.dolphinscheduler.common.utils.DependentUtils;
-import org.apache.dolphinscheduler.common.utils.*;
+import org.apache.dolphinscheduler.common.utils.JSONUtils;
 import org.apache.dolphinscheduler.common.utils.LoggerUtils;
 import org.apache.dolphinscheduler.common.utils.NetUtils;
 import org.apache.dolphinscheduler.dao.entity.TaskInstance;
 import org.apache.dolphinscheduler.server.utils.LogUtils;
-
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.LoggerFactory;
 
 public class ConditionsTaskExecThread extends MasterBaseTaskExecThread {
 

--- a/pom.xml
+++ b/pom.xml
@@ -754,6 +754,7 @@
                         <include>**/api/utils/CheckUtilsTest.java</include>
                         <include>**/api/utils/ResultTest.java</include>
                         <include>**/common/graph/DAGTest.java</include>
+                        <include>**/common/model/TaskNodeTest.java</include>
                         <include>**/common/os/OshiTest.java</include>
                         <include>**/common/os/OSUtilsTest.java</include>
                         <include>**/common/shell/ShellExecutorTest.java</include>
@@ -816,6 +817,7 @@
                         <include>**/server/log/WorkerLogFilterTest.java</include>
                         <include>**/server/master/consumer/TaskPriorityQueueConsumerTest.java</include>
                         <include>**/server/master/runner/MasterTaskExecThreadTest.java</include>
+                        <include>**/server/master/runner/DependentTaskExecThreadTest.java</include>
                         <!--<include>**/server/master/dispatch/executor/NettyExecutorManagerTest.java</include>-->
                         <include>**/server/master/dispatch/host/assign/LowerWeightRoundRobinTest.java</include>
                         <include>**/server/master/dispatch/host/assign/RandomSelectorTest.java</include>


### PR DESCRIPTION
## What is the purpose of the pull request

- Added a function that allows dependent nodes to wait for a period of time before the pre-dependency starts;
- Added test files for new features;
- Remove unnecessary start time initialization code in `DependentTaskExecThread` and `ConditionsTaskExecThread`;
- Standardize the format of some source codes.

## Related issues

- [Feature][Server] Let dependent nodes wait for a while before the pre-process starts [#3633](https://github.com/apache/incubator-dolphinscheduler/issues/3633)

## Brief change log

- `dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/task/TaskTimeoutParameter.java` added check interval properties;
- `dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/model/TaskNode.java` standardized format, and add new timeout attribute for dependent node;
- `dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/DependentTaskExecThread.java` and `dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/ DependentExecute.java` adds new feature implementation code;
- `dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/master/runner/DependentTaskExecThreadTest.java` adds new feature test code.

## Verify this pull request

Both the new test and the original test have passed.