### PR TITLE
[fix-3745][server] server get tasktype NPE exception

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/TaskParametersUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/TaskParametersUtils.java
@@ -55,41 +55,42 @@ public class TaskParametersUtils {
      * @return task parameters
      */
     public static AbstractParameters getParameters(String taskType, String parameter) {
-        try {
-            switch (EnumUtils.getEnum(TaskType.class, taskType)) {
-                case SUB_PROCESS:
-                    return JSONUtils.parseObject(parameter, SubProcessParameters.class);
-                case SHELL:
-                case WATERDROP:
-                    return JSONUtils.parseObject(parameter, ShellParameters.class);
-                case PROCEDURE:
-                    return JSONUtils.parseObject(parameter, ProcedureParameters.class);
-                case SQL:
-                    return JSONUtils.parseObject(parameter, SqlParameters.class);
-                case MR:
-                    return JSONUtils.parseObject(parameter, MapreduceParameters.class);
-                case SPARK:
-                    return JSONUtils.parseObject(parameter, SparkParameters.class);
-                case PYTHON:
-                    return JSONUtils.parseObject(parameter, PythonParameters.class);
-                case DEPENDENT:
-                    return JSONUtils.parseObject(parameter, DependentParameters.class);
-                case FLINK:
-                    return JSONUtils.parseObject(parameter, FlinkParameters.class);
-                case HTTP:
-                    return JSONUtils.parseObject(parameter, HttpParameters.class);
-                case DATAX:
-                    return JSONUtils.parseObject(parameter, DataxParameters.class);
-                case CONDITIONS:
-                    return JSONUtils.parseObject(parameter, ConditionsParameters.class);
-                case SQOOP:
-                    return JSONUtils.parseObject(parameter, SqoopParameters.class);
-                default:
-                    return null;
-            }
-        } catch (Exception e) {
-            logger.error(e.getMessage(), e);
+        TaskType anEnum = EnumUtils.getEnum(TaskType.class, taskType);
+        if (anEnum == null) {
+            logger.error("not support task type: {}", taskType);
+            return null;
         }
-        return null;
+        switch (anEnum) {
+            case SUB_PROCESS:
+                return JSONUtils.parseObject(parameter, SubProcessParameters.class);
+            case SHELL:
+            case WATERDROP:
+                return JSONUtils.parseObject(parameter, ShellParameters.class);
+            case PROCEDURE:
+                return JSONUtils.parseObject(parameter, ProcedureParameters.class);
+            case SQL:
+                return JSONUtils.parseObject(parameter, SqlParameters.class);
+            case MR:
+                return JSONUtils.parseObject(parameter, MapreduceParameters.class);
+            case SPARK:
+                return JSONUtils.parseObject(parameter, SparkParameters.class);
+            case PYTHON:
+                return JSONUtils.parseObject(parameter, PythonParameters.class);
+            case DEPENDENT:
+                return JSONUtils.parseObject(parameter, DependentParameters.class);
+            case FLINK:
+                return JSONUtils.parseObject(parameter, FlinkParameters.class);
+            case HTTP:
+                return JSONUtils.parseObject(parameter, HttpParameters.class);
+            case DATAX:
+                return JSONUtils.parseObject(parameter, DataxParameters.class);
+            case CONDITIONS:
+                return JSONUtils.parseObject(parameter, ConditionsParameters.class);
+            case SQOOP:
+                return JSONUtils.parseObject(parameter, SqoopParameters.class);
+            default:
+                return null;
+        }
+
     }
 }

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/TaskManager.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/TaskManager.java
@@ -74,8 +74,9 @@ public class TaskManager {
             case SQOOP:
                 return new SqoopTask(taskExecutionContext, logger);
             default:
-                logger.error("not support task type: {}", taskExecutionContext.getTaskType());
-                throw new IllegalArgumentException("not support task type");
+                String msg = String.format("not support task type: %s", taskExecutionContext.getTaskType());
+                logger.error(msg);
+                throw new IllegalArgumentException(msg);
         }
     }
 }

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/TaskManager.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/TaskManager.java
@@ -30,7 +30,6 @@ import org.apache.dolphinscheduler.server.worker.task.shell.ShellTask;
 import org.apache.dolphinscheduler.server.worker.task.spark.SparkTask;
 import org.apache.dolphinscheduler.server.worker.task.sql.SqlTask;
 import org.apache.dolphinscheduler.server.worker.task.sqoop.SqoopTask;
-
 import org.slf4j.Logger;
 
 /**
@@ -46,7 +45,13 @@ public class TaskManager {
      * @throws IllegalArgumentException illegal argument exception
      */
     public static AbstractTask newTask(TaskExecutionContext taskExecutionContext, Logger logger) throws IllegalArgumentException {
-        switch (EnumUtils.getEnum(TaskType.class,taskExecutionContext.getTaskType())) {
+        TaskType anEnum = EnumUtils.getEnum(TaskType.class, taskExecutionContext.getTaskType());
+        if (anEnum == null) {
+            String msg = String.format("not support task type: %s", taskExecutionContext.getTaskType());
+            logger.error(msg);
+            throw new IllegalArgumentException(msg);
+        }
+        switch (anEnum) {
             case SHELL:
             case WATERDROP:
                 return new ShellTask(taskExecutionContext, logger);
@@ -69,7 +74,7 @@ public class TaskManager {
             case SQOOP:
                 return new SqoopTask(taskExecutionContext, logger);
             default:
-                logger.error("unsupport task type: {}", taskExecutionContext.getTaskType());
+                logger.error("not support task type: {}", taskExecutionContext.getTaskType());
                 throw new IllegalArgumentException("not support task type");
         }
     }

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/TaskManager.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/TaskManager.java
@@ -47,9 +47,8 @@ public class TaskManager {
     public static AbstractTask newTask(TaskExecutionContext taskExecutionContext, Logger logger) throws IllegalArgumentException {
         TaskType anEnum = EnumUtils.getEnum(TaskType.class, taskExecutionContext.getTaskType());
         if (anEnum == null) {
-            String msg = String.format("not support task type: %s", taskExecutionContext.getTaskType());
-            logger.error(msg);
-            throw new IllegalArgumentException(msg);
+            logger.error("not support task type: {}", taskExecutionContext.getTaskType());
+            throw new IllegalArgumentException("not support task type");
         }
         switch (anEnum) {
             case SHELL:
@@ -74,9 +73,8 @@ public class TaskManager {
             case SQOOP:
                 return new SqoopTask(taskExecutionContext, logger);
             default:
-                String msg = String.format("not support task type: %s", taskExecutionContext.getTaskType());
-                logger.error(msg);
-                throw new IllegalArgumentException(msg);
+                logger.error("not support task type: {}", taskExecutionContext.getTaskType());
+                throw new IllegalArgumentException("not support task type");
         }
     }
 }

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/worker/task/TaskManagerTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/worker/task/TaskManagerTest.java
@@ -21,6 +21,9 @@ import org.apache.dolphinscheduler.common.utils.LoggerUtils;
 import org.apache.dolphinscheduler.server.entity.TaskExecutionContext;
 import org.apache.dolphinscheduler.server.worker.cache.impl.TaskExecutionContextCacheManagerImpl;
 import org.apache.dolphinscheduler.service.bean.SpringApplicationContext;
+
+import java.util.Date;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,8 +33,6 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Date;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({SpringApplicationContext.class})
@@ -96,17 +97,17 @@ public class TaskManagerTest {
         Assert.assertNotNull(TaskManager.newTask(taskExecutionContext,taskLogger));
         taskExecutionContext.setTaskType("SQOOP");
         Assert.assertNotNull(TaskManager.newTask(taskExecutionContext,taskLogger));
-        try{
+        try {
             taskExecutionContext.setTaskType(null);
             TaskManager.newTask(taskExecutionContext,taskLogger);
-        }catch (Exception e){
+        } catch (Exception e) {
             logger.error(e.getMessage());
         }
 
-        try{
+        try {
             taskExecutionContext.setTaskType("XXX");
             TaskManager.newTask(taskExecutionContext,taskLogger);
-        }catch (Exception e){
+        } catch (Exception e) {
             logger.error(e.getMessage());
         }
 

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/worker/task/TaskManagerTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/worker/task/TaskManagerTest.java
@@ -97,19 +97,18 @@ public class TaskManagerTest {
         Assert.assertNotNull(TaskManager.newTask(taskExecutionContext,taskLogger));
         taskExecutionContext.setTaskType("SQOOP");
         Assert.assertNotNull(TaskManager.newTask(taskExecutionContext,taskLogger));
-        try {
-            taskExecutionContext.setTaskType(null);
-            TaskManager.newTask(taskExecutionContext,taskLogger);
-        } catch (Exception e) {
-            logger.error(e.getMessage());
-        }
 
-        try {
-            taskExecutionContext.setTaskType("XXX");
-            TaskManager.newTask(taskExecutionContext,taskLogger);
-        } catch (Exception e) {
-            logger.error(e.getMessage());
-        }
+    }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testNewTaskIsNull() {
+        taskExecutionContext.setTaskType(null);
+        TaskManager.newTask(taskExecutionContext,taskLogger);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNewTaskIsNotExists() {
+        taskExecutionContext.setTaskType("XXX");
+        TaskManager.newTask(taskExecutionContext,taskLogger);
     }
 }

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/worker/task/TaskManagerTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/worker/task/TaskManagerTest.java
@@ -21,9 +21,6 @@ import org.apache.dolphinscheduler.common.utils.LoggerUtils;
 import org.apache.dolphinscheduler.server.entity.TaskExecutionContext;
 import org.apache.dolphinscheduler.server.worker.cache.impl.TaskExecutionContextCacheManagerImpl;
 import org.apache.dolphinscheduler.service.bean.SpringApplicationContext;
-
-import java.util.Date;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,9 +31,13 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Date;
+
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({SpringApplicationContext.class})
 public class TaskManagerTest {
+
+    private static Logger logger = LoggerFactory.getLogger(TaskManagerTest.class);
 
     private TaskExecutionContext taskExecutionContext;
 
@@ -95,9 +96,19 @@ public class TaskManagerTest {
         Assert.assertNotNull(TaskManager.newTask(taskExecutionContext,taskLogger));
         taskExecutionContext.setTaskType("SQOOP");
         Assert.assertNotNull(TaskManager.newTask(taskExecutionContext,taskLogger));
-        //taskExecutionContext.setTaskType(null);
-        //Assert.assertNull(TaskManager.newTask(taskExecutionContext,taskLogger));
-        //taskExecutionContext.setTaskType("XXX");
-        //Assert.assertNotNull(TaskManager.newTask(taskExecutionContext,taskLogger));
+        try{
+            taskExecutionContext.setTaskType(null);
+            TaskManager.newTask(taskExecutionContext,taskLogger);
+        }catch (Exception e){
+            logger.error(e.getMessage());
+        }
+
+        try{
+            taskExecutionContext.setTaskType("XXX");
+            TaskManager.newTask(taskExecutionContext,taskLogger);
+        }catch (Exception e){
+            logger.error(e.getMessage());
+        }
+
     }
 }


### PR DESCRIPTION
## What is the purpose of the pull request
#3745 
```
switch (EnumUtils.getEnum(TaskType.class,taskExecutionContext.getTaskType()))
```
When the task type does not exist in the enumeration class TaskType, EnumUtils.getEnum() returns null, and switch will report a null pointer exception

## Brief change log

1.TaskParametersUtils  switch tasktype param is not null
1.TaskManager switch tasktype  param is not null

## Verify this pull request

This pull request is already covered by existing tests, such as *(please describe tests)*.

TaskParametersUtilsTest
TaskManagerTest
