### PR TITLE
[Fix-3750][tools] check-LICENSE.sh: support sub dirs in dist/lib

### DIFF
--- a/tools/dependencies/check-LICENSE.sh
+++ b/tools/dependencies/check-LICENSE.sh
@@ -25,7 +25,9 @@ tar -zxf dolphinscheduler-dist/target/apache-dolphinscheduler*-bin.tar.gz --stri
 # licenses
 echo '=== Self modules: ' && ./mvnw --batch-mode --quiet -Dexec.executable='echo' -Dexec.args='${project.artifactId}-${project.version}.jar' exec:exec | tee self-modules.txt
 
-echo '=== Distributed dependencies: ' && ls dist/lib | tee all-dependencies.txt
+echo '=== Distributed dependencies: ' && find dist/lib -name "*.jar" | tee all-dependencies.txt
+# The prefix "dist/lib/" (9 chars) should be stripped to be ready to compare
+sed -i 's/.\{9\}//' all-dependencies.txt
 
 # Exclude all self modules(jars) to generate all third-party dependencies
 echo '=== Third party dependencies: ' && grep -vf self-modules.txt all-dependencies.txt | tee third-party-dependencies.txt


### PR DESCRIPTION
## What is the purpose of the pull request

- impl #3750 

## Brief change log

- use `find` + `sed` instead of `ls` to fix the problem.

## Verify this pull request

This change added tests and can be verified as follows:

- No test case cover it, so you should run the script manually.
