### PR TITLE
[Feature]add "shell task" support for varpool

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/VarPoolUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/VarPoolUtils.java
@@ -90,14 +90,15 @@ public class VarPoolUtils {
             }
         }
     }
-
+    
     /**
-     * convertPythonScriptPlaceholders
+     * convertScriptPlaceholders
      * @param rawScript rawScript
+     * @param formate formate
      * @return String
      * @throws StringIndexOutOfBoundsException StringIndexOutOfBoundsException
      */
-    public static String convertPythonScriptPlaceholders(String rawScript) throws StringIndexOutOfBoundsException {
+    public static String convertScriptPlaceholders(String rawScript, String format) throws StringIndexOutOfBoundsException {
         int len = "${setShareVar(${".length();
         int scriptStart = 0;
         while ((scriptStart = rawScript.indexOf("${setShareVar(${", scriptStart)) != -1) {
@@ -113,13 +114,23 @@ public class VarPoolUtils {
             start = rawScript.indexOf('}', start) + 1;
             end = rawScript.length();
 
-            String replaceScript = String.format("print(\"${{setValue({},{})}}\".format(\"%s\",%s))", prop, value);
+            String replaceScript = String.format(format, prop, value);
 
             rawScript = rawScript.substring(0, scriptStart) + replaceScript + rawScript.substring(start, end);
 
             scriptStart += replaceScript.length();
         }
         return rawScript;
+    }
+
+    /**
+     * convertPythonScriptPlaceholders
+     * @param rawScript rawScript
+     * @return String
+     * @throws StringIndexOutOfBoundsException StringIndexOutOfBoundsException
+     */
+    public static String convertPythonScriptPlaceholders(String rawScript) throws StringIndexOutOfBoundsException {
+        return convertScriptPlaceholders(rawScript, "print(\"${{setValue({},{})}}\".format(\"%s\",%s))");
     }
     
     /**
@@ -129,27 +140,6 @@ public class VarPoolUtils {
      * @throws StringIndexOutOfBoundsException StringIndexOutOfBoundsException
      */
     public static String convertShellScriptPlaceholders(String rawScript) throws StringIndexOutOfBoundsException {
-        int len = "${setShareVar(${".length();
-        int scriptStart = 0;
-        while ((scriptStart = rawScript.indexOf("${setShareVar(${", scriptStart)) != -1) {
-            int start = -1;
-            int end = rawScript.indexOf('}', scriptStart + len);
-            String prop = rawScript.substring(scriptStart + len, end);
-
-            start = rawScript.indexOf(',', end);
-            end = rawScript.indexOf(')', start);
-
-            String value = rawScript.substring(start + 1, end);
-
-            start = rawScript.indexOf('}', start) + 1;
-            end = rawScript.length();
-
-            String replaceScript = String.format("echo \"\\${setValue(%s,%s)}\"", prop, value);
-
-            rawScript = rawScript.substring(0, scriptStart) + replaceScript + rawScript.substring(start, end);
-
-            scriptStart += replaceScript.length();
-        }
-        return rawScript;
+        return convertScriptPlaceholders(rawScript, "echo \"\\${setValue(%s,%s)}\"");
     }
 } 

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/VarPoolUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/VarPoolUtils.java
@@ -121,4 +121,35 @@ public class VarPoolUtils {
         }
         return rawScript;
     }
+    
+    /**
+     * convertShellScriptPlaceholders
+     * @param rawScript rawScript
+     * @return String
+     * @throws StringIndexOutOfBoundsException StringIndexOutOfBoundsException
+     */
+    public static String convertShellScriptPlaceholders(String rawScript) throws StringIndexOutOfBoundsException {
+        int len = "${setShareVar(${".length();
+        int scriptStart = 0;
+        while ((scriptStart = rawScript.indexOf("${setShareVar(${", scriptStart)) != -1) {
+            int start = -1;
+            int end = rawScript.indexOf('}', scriptStart + len);
+            String prop = rawScript.substring(scriptStart + len, end);
+
+            start = rawScript.indexOf(',', end);
+            end = rawScript.indexOf(')', start);
+
+            String value = rawScript.substring(start + 1, end);
+
+            start = rawScript.indexOf('}', start) + 1;
+            end = rawScript.length();
+
+            String replaceScript = String.format("echo \"\\${setValue(%s,%s)}\"", prop, value);
+
+            rawScript = rawScript.substring(0, scriptStart) + replaceScript + rawScript.substring(start, end);
+
+            scriptStart += replaceScript.length();
+        }
+        return rawScript;
+    }
 } 

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/VarPoolUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/VarPoolUtilsTest.java
@@ -70,4 +70,13 @@ public class VarPoolUtilsTest {
             + "print(\"${{setValue({},{})}}\".format(\"p2\",4));");
         logger.info(rawScript);
     }
+    
+    @Test
+    public void testConvertShellScriptPlaceholders() throws Exception {
+        String rawScript = "value=600+60+6\n${setShareVar(${p1},$value)}";
+        rawScript = VarPoolUtils.convertShellScriptPlaceholders(rawScript);
+        Assert.assertEquals(rawScript, "value=600+60+6\n"
+            + "echo \"\\${setValue(p1,$value)}\"");
+        logger.info(rawScript);
+    }
 }

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/shell/ShellTask.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/shell/ShellTask.java
@@ -133,12 +133,12 @@ public class ShellTask extends AbstractTask {
             CommandType.of(taskExecutionContext.getCmdTypeIfComplement()),
             taskExecutionContext.getScheduleTime());
     
-    try {
-      script = VarPoolUtils.convertShellScriptPlaceholders(script);
-    }
-    catch (StringIndexOutOfBoundsException e) {
-        logger.error("setShareVar field format error, raw shell script : {}", script);
-    }
+        try {
+            script = VarPoolUtils.convertShellScriptPlaceholders(script);
+        }
+        catch (StringIndexOutOfBoundsException e) {
+            logger.error("setShareVar field format error, raw shell script : {}", script);
+        }
     
     if (paramsMap != null){
       script = ParameterUtils.convertParameterPlaceholders(script, ParamUtils.convert(paramsMap));

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/shell/ShellTask.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/shell/ShellTask.java
@@ -22,10 +22,7 @@ import org.apache.dolphinscheduler.common.enums.CommandType;
 import org.apache.dolphinscheduler.common.process.Property;
 import org.apache.dolphinscheduler.common.task.AbstractParameters;
 import org.apache.dolphinscheduler.common.task.shell.ShellParameters;
-import org.apache.dolphinscheduler.common.utils.DateUtils;
 import org.apache.dolphinscheduler.common.utils.*;
-import org.apache.dolphinscheduler.common.utils.OSUtils;
-import org.apache.dolphinscheduler.common.utils.ParameterUtils;
 import org.apache.dolphinscheduler.server.entity.TaskExecutionContext;
 import org.apache.dolphinscheduler.server.utils.ParamUtils;
 import org.apache.dolphinscheduler.server.worker.task.AbstractTask;
@@ -135,6 +132,14 @@ public class ShellTask extends AbstractTask {
             shellParameters.getLocalParametersMap(),
             CommandType.of(taskExecutionContext.getCmdTypeIfComplement()),
             taskExecutionContext.getScheduleTime());
+    
+    try {
+      script = VarPoolUtils.convertShellScriptPlaceholders(script);
+    }
+    catch (StringIndexOutOfBoundsException e) {
+        logger.error("setShareVar field format error, raw shell script : {}", script);
+    }
+    
     if (paramsMap != null){
       script = ParameterUtils.convertParameterPlaceholders(script, ParamUtils.convert(paramsMap));
     }


### PR DESCRIPTION
Signed-off-by: 古崟佑

The function of varpool is implemented in <https://github.com/apache/incubator-dolphinscheduler/pull/3659>, but only Python type tasks are supported. Shell type tasks are supported in this pr

-----------------------------------------------------------------------------------------------------------------------------


<https://github.com/apache/incubator-dolphinscheduler/pull/3659>中实现了Varpool的功能，但是只支持python类型的任务，在这次pr中增加了对shell类型任务的支持