### PR TITLE
[fix-3843][api] When the update workflow definition name already exists, the prompt is not friendly add process define name verify.

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProcessDefinitionServiceImpl.java
@@ -434,7 +434,7 @@ public class ProcessDefinitionServiceImpl extends BaseService implements
         if (resultEnum != Status.SUCCESS) {
             return checkResult;
         }
-        ProcessDefinition processDefinition = processDefineMapper.queryByDefineName(project.getId(), name);
+        ProcessDefinition processDefinition = processDefineMapper.verifyByDefineName(project.getId(), name);
         if (processDefinition == null) {
             putMsg(result, Status.SUCCESS);
         } else {

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProcessDefinitionServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProcessDefinitionServiceTest.java
@@ -618,13 +618,13 @@ public class ProcessDefinitionServiceTest {
 
         //project check auth success, process not exist
         putMsg(result, Status.SUCCESS, projectName);
-        Mockito.when(processDefineMapper.queryByDefineName(project.getId(), "test_pdf")).thenReturn(null);
+        Mockito.when(processDefineMapper.verifyByDefineName(project.getId(), "test_pdf")).thenReturn(null);
         Map<String, Object> processNotExistRes = processDefinitionService.verifyProcessDefinitionName(loginUser,
                 "project_test1", "test_pdf");
         Assert.assertEquals(Status.SUCCESS, processNotExistRes.get(Constants.STATUS));
 
         //process exist
-        Mockito.when(processDefineMapper.queryByDefineName(project.getId(), "test_pdf")).thenReturn(getProcessDefinition());
+        Mockito.when(processDefineMapper.verifyByDefineName(project.getId(), "test_pdf")).thenReturn(getProcessDefinition());
         Map<String, Object> processExistRes = processDefinitionService.verifyProcessDefinitionName(loginUser,
                 "project_test1", "test_pdf");
         Assert.assertEquals(Status.PROCESS_INSTANCE_EXIST, processExistRes.get(Constants.STATUS));

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/ProcessDefinitionMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/ProcessDefinitionMapper.java
@@ -34,6 +34,15 @@ import com.baomidou.mybatisplus.core.metadata.IPage;
  */
 public interface ProcessDefinitionMapper extends BaseMapper<ProcessDefinition> {
 
+    /**
+     * verify process definition by name
+     *
+     * @param projectId projectId
+     * @param name name
+     * @return process definition
+     */
+    ProcessDefinition verifyByDefineName(@Param("projectId") int projectId,
+                                        @Param("processDefinitionName") String name);
 
     /**
      * query process definition by name

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessDefinitionMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessDefinitionMapper.xml
@@ -18,6 +18,12 @@
 
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
 <mapper namespace="org.apache.dolphinscheduler.dao.mapper.ProcessDefinitionMapper">
+    <select id="verifyByDefineName" resultType="org.apache.dolphinscheduler.dao.entity.ProcessDefinition">
+        select pd.*
+        from t_ds_process_definition pd
+        WHERE pd.project_id = #{projectId}
+        and pd.name = #{processDefinitionName}
+    </select>
     <select id="queryByDefineName" resultType="org.apache.dolphinscheduler.dao.entity.ProcessDefinition">
         select pd.*,u.user_name,p.name as project_name,t.tenant_code,t.tenant_name,q.queue,q.queue_name
         from t_ds_process_definition pd


### PR DESCRIPTION
## What is the purpose of the pull request
#3843 

problem:
The workflow definition name already exists, saved workflow ，prompt: update workflow definition error

The reason for this problem is that the user tenant or queue or project is empty. When the workflow definition is saved, the verification of the workflow definition name fails, the projectId and processDefineName construct unique constraints, and the workflow update fails when the data is saved.

I think that the workflow definition name verification only needs to verify the existence of projectId and processDefineName,The original query method is called in many places without modification.

```
 select pd.*,u.user_name,p.name as project_name,t.tenant_code,t.tenant_name,q.queue,q.queue_name
        from t_ds_process_definition pd
        JOIN t_ds_user u ON pd.user_id = u.id
        JOIN  t_ds_project p ON pd.project_id = p.id
        JOIN  t_ds_tenant t ON t.id = u.tenant_id
        JOIN t_ds_queue q ON t.queue_id = q.id
        WHERE p.id = #{projectId}
        and pd.name = #{processDefinitionName}
```
add verifyByDefineName
```
select pd.*
        from t_ds_process_definition pd
        WHERE pd.project_id = #{projectId}
        and pd.name = #{processDefinitionName}
```

## Brief change log

add ProcessDefinitionMapper.verifyByDefineName(int projectId,String name)

## Verify this pull request
This change added tests and can be verified as follows:
  - *Manually verified the change by testing locally.*

---

##拉取请求的目的是什么
问题
工作流程定义名称已存在，更新工作流定义，保存名称，提示：更新工作流程定义错误

出现这个问题的原因,用户租户或队列或项目为空导致，导致工作流定义保存时，工作流定义名称验证失败，projectId和processDefineName构建唯一约束，数据保存时报工作流更新失败。

我认为工作流定义名称验证，只需要验证projectId和processDefineName是否存在即可，原查询方法多处调用，并未做修改。

```
 select pd.*,u.user_name,p.name as project_name,t.tenant_code,t.tenant_name,q.queue,q.queue_name
        from t_ds_process_definition pd
        JOIN t_ds_user u ON pd.user_id = u.id
        JOIN  t_ds_project p ON pd.project_id = p.id
        JOIN  t_ds_tenant t ON t.id = u.tenant_id
        JOIN t_ds_queue q ON t.queue_id = q.id
        WHERE p.id = #{projectId}
        and pd.name = #{processDefinitionName}
```
add verifyByDefineName
```
select pd.*
        from t_ds_process_definition pd
        WHERE pd.project_id = #{projectId}
        and pd.name = #{processDefinitionName}
```

##简要更改日志

新增ProcessDefinitionMapper.verifyByDefineName(int projectId,String name)