### PR TITLE
[fix-3835][ui] When the tenantName contains "<", the tenant drop-down list is blankadd verify tenant name cannot contain special characters.

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/pages/security/pages/tenement/_source/createTenement.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/security/pages/tenement/_source/createTenement.vue
@@ -146,6 +146,13 @@
           this.$message.warning(`${i18n.$t('Please enter name')}`)
           return false
         }
+        // Verify tenant name cannot contain special characters
+        let isSpecial = /[~#^$@%&!*()<>《》:;'"{}【】	]/gi
+        if (isSpecial.test(this.tenantName)) {
+          this.$message.warning(`${i18n.$t('Please enter tenant name without special characters')}`)
+          return false
+        }
+
         return true
       },
       _submit () {

--- a/dolphinscheduler-ui/src/js/module/i18n/locale/en_US.js
+++ b/dolphinscheduler-ui/src/js/module/i18n/locale/en_US.js
@@ -186,6 +186,7 @@ export default {
   'Please select a queue': 'default is tenant association queue',
   'Please enter the tenant code in English': 'Please enter the tenant code in English',
   'Please enter tenant code in English': 'Please enter tenant code in English',
+  'Please enter tenant name without special characters': 'Please enter tenant name without special characters',
   'Edit User': 'Edit User',
   Tenant: 'Tenant',
   Email: 'Email',

--- a/dolphinscheduler-ui/src/js/module/i18n/locale/zh_CN.js
+++ b/dolphinscheduler-ui/src/js/module/i18n/locale/zh_CN.js
@@ -188,6 +188,7 @@ export default {
   Queue: 'Yarn 队列',
   'Please enter the tenant code in English': '请输入租户编码只允许英文',
   'Please enter tenant code in English': '请输入英文租户编码',
+  'Please enter tenant name without special characters': '请输入不包含特殊字符的租户名称',
   'Edit User': '编辑用户',
   Tenant: '租户',
   Email: '邮件',


### PR DESCRIPTION

## What is the purpose of the pull request

#3835 

When the tenant name contains "<", when creating/editing users and saving workflows, the tenant drop-down list data is blank

## Brief change log

add verify tenant name cannot contain special characters.
```
 let isSpecial = /[~#^$@%&!*()<>《》:;'"{}【】	]/gi
        if (isSpecial.test(this.tenantName)) {
          this.$message.warning(`${i18n.$t('Please enter tenant name without special characters')}`)
          return false
        }
```

## Verify this pull request
This change added tests and can be verified as follows:
  - *Manually verified the change by testing locally.*
