### PR TITLE
Revert "[1.3.3-release][fix-3835][ui] When the tenantName contains "<", the tenant drop-down list is blankadd verify tenant name cannot contain special characters."

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/pages/security/pages/tenement/_source/createTenement.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/security/pages/tenement/_source/createTenement.vue
@@ -149,13 +149,6 @@
           this.$message.warning(`${i18n.$t('Please enter tenant Name')}`)
           return false
         }
-        // Verify tenant name cannot contain special characters
-        let isSpecial = /[~#^$@%&!*()<>《》:;'"{}【】	]/gi
-        if (isSpecial.test(this.tenantName)) {
-          this.$message.warning(`${i18n.$t('Please enter tenant name without special characters')}`)
-          return false
-        }
-
         return true
       },
       _submit () {

--- a/dolphinscheduler-ui/src/js/module/i18n/locale/en_US.js
+++ b/dolphinscheduler-ui/src/js/module/i18n/locale/en_US.js
@@ -177,7 +177,6 @@ export default {
   'Please enter tenant Name': 'Please enter tenant Name',
   'The tenant code. Only letters or a combination of letters and numbers are allowed': 'The tenant code. Only letters or a combination of letters and numbers are allowed',
   'The tenant code cannot be all numbers': 'The tenant code cannot be all numbers',
-  'Please enter tenant name without special characters': 'Please enter tenant name without special characters',
   'Edit User': 'Edit User',
   Tenant: 'Tenant',
   Email: 'Email',

--- a/dolphinscheduler-ui/src/js/module/i18n/locale/zh_CN.js
+++ b/dolphinscheduler-ui/src/js/module/i18n/locale/zh_CN.js
@@ -179,7 +179,6 @@ export default {
   'Please enter tenant code': '请输入租户编码',
   'Please enter tenant Name': '请输入租户名称',
   'The tenant code. Only letters or a combination of letters and numbers are allowed': '租户编码只允许字母或字母与数字组合',
-  'Please enter tenant name without special characters': '请输入不包含特殊字符的租户名称',
   'Edit User': '编辑用户',
   Tenant: '租户',
   Email: '邮件',


### PR DESCRIPTION
Reverts apache/incubator-dolphinscheduler#3870