### PR TITLE
[Improvement][dao] queryTaskInstanceListPaging query slow

### DIFF
--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.xml
@@ -98,7 +98,8 @@
         </if>
     </select>
     <select id="queryTaskInstanceListPaging" resultType="org.apache.dolphinscheduler.dao.entity.TaskInstance">
-        select instance.*,process.name as process_instance_name
+        select instance.id,instance.name,instance.task_type,instance.process_definition_id,instance.process_instance_id,instance.state,instance.submit_time,instance.start_time,instance.end_time,
+        instance.host,instance.execute_path,instance.log_path,instance.alert_flag,instance.retry_times,instance.pid,instance.app_link,instance.flag,instance.retry_interval,instance.max_retry_times,instance.task_instance_priority,instance.worker_group,instance.executor_id,process.name as process_instance_name
         from t_ds_task_instance instance
         join t_ds_process_definition define ON instance.process_definition_id = define.id
         join  t_ds_process_instance process on process.id=instance.process_instance_id


### PR DESCRIPTION
because queryTaskInstanceListPaging  has contain longtext  type field  by instance.*,so  queryTaskInstanceListPaging query slow , but longtext  field not used.

## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds checkstyle plugin.)*

## Brief change log

*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.*
