### PR TITLE
[Improvement][dao] queryProcessInstanceListPaging query slow

### DIFF
--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessInstanceMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessInstanceMapper.xml
@@ -76,7 +76,10 @@
     </select>
 
     <select id="queryProcessInstanceListPaging" resultType="org.apache.dolphinscheduler.dao.entity.ProcessInstance">
-        select instance.*
+        select instance.id,instance.name,instance.process_definition_id,instance.state,instance.recovery,instance.start_time,instance.end_time,instance.run_times,instance.host,instance.command_type,instance.command_param,
+        instance.task_depend_type,instance.max_try_times,instance.failure_strategy,instance.warning_type,instance.warning_group_id,instance.schedule_time,instance.command_start_time,instance.global_params,instance.flag,
+        instance.update_time,instance.is_sub_process,instance.executor_id,instance.locations,instance.connects,instance.history_cmd,instance.dependence_schedule_times,instance.process_instance_priority,instance.worker_group,
+        instance.timeout,instance.tenant_id
         from t_ds_process_instance instance
         join t_ds_process_definition define ON instance.process_definition_id = define.id
         where 1=1


### PR DESCRIPTION
because queryProcessInstanceListPaging has contain longtext type field by instance.*,so queryProcessInstanceListPaging query slow , but longtext field not used.

## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds checkstyle plugin.)*

## Brief change log

*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.*
