### PR TITLE
[Fix][Docker] fix startup.sh variables cannot reference in single quotes.

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -42,8 +42,8 @@ ADD ./apache-dolphinscheduler-incubating-${VERSION}-dolphinscheduler-bin.tar.gz 
 RUN mv /opt/apache-dolphinscheduler-incubating-${VERSION}-dolphinscheduler-bin/ /opt/dolphinscheduler/
 ENV DOLPHINSCHEDULER_HOME /opt/dolphinscheduler
 
-#4. install database, if use mysql as your backend database, the `mysql-client` package should be installed
-RUN apk add --update --no-cache postgresql postgresql-contrib mariadb-client
+#4. install database, if use mysql as your backend database, you should append `mysql-client` at the end of the sentence
+RUN apk add --update --no-cache postgresql postgresql-contrib
 
 #5. modify nginx
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf && \

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -43,7 +43,7 @@ RUN mv /opt/apache-dolphinscheduler-incubating-${VERSION}-dolphinscheduler-bin/ 
 ENV DOLPHINSCHEDULER_HOME /opt/dolphinscheduler
 
 #4. install database, if use mysql as your backend database, the `mysql-client` package should be installed
-RUN apk add --update --no-cache postgresql postgresql-contrib
+RUN apk add --update --no-cache postgresql postgresql-contrib mariadb-client
 
 #5. modify nginx
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf && \

--- a/docker/build/startup.sh
+++ b/docker/build/startup.sh
@@ -38,13 +38,13 @@ initDatabase() {
     echo "connect ${DATABASE_TYPE} service"
     if [ ${DATABASE_TYPE} = "mysql" ]; then
         v=$(mysql -h${DATABASE_HOST} -P${DATABASE_PORT} -u${DATABASE_USERNAME} --password=${DATABASE_PASSWORD} -D ${DATABASE_DATABASE} -e "select 1" 2>&1)
-        if [ "$(echo '${v}' | grep 'ERROR' | wc -l)" -eq 1 ]; then
+        if [ "$(echo ${v} | grep 'ERROR' | wc -l)" -eq 1 ]; then
             echo "Error: Can't connect to database...${v}"
             exit 1
         fi
     else
         v=$(sudo -u postgres PGPASSWORD=${DATABASE_PASSWORD} psql -h ${DATABASE_HOST} -p ${DATABASE_PORT} -U ${DATABASE_USERNAME} -d ${DATABASE_DATABASE} -tAc "select 1")
-        if [ "$(echo '${v}' | grep 'FATAL' | wc -l)" -eq 1 ]; then
+        if [ "$(echo ${v} | grep 'FATAL' | wc -l)" -eq 1 ]; then
             echo "Error: Can't connect to database...${v}"
             exit 1
         fi


### PR DESCRIPTION

Signed-off-by: Youngman <bushengquan@gmail.com>

## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

## What is the purpose of the pull request

*This pull request fix startup.sh variables cannot reference in single quotes. (#3894)*

## Brief change log

  - *Fix docker/build/startu.sh a variables without single quotes (#3894)*
  - *Add mysql-client in Dockerfile to support  mysql as backend database.*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.*
