### PR TITLE
[FIX-3615] master exit  gracefully 

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterExecThread.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterExecThread.java
@@ -973,7 +973,7 @@ public class MasterExecThread implements Runnable {
         // submit start node
         submitPostNode(null);
         boolean sendTimeWarning = false;
-        while(!processInstance.isProcessInstanceStop()){
+        while(!processInstance.isProcessInstanceStop() && Stopper.isRunning()){
 
             // send warning email if process time out.
             if(!sendTimeWarning && checkProcessTimeOut(processInstance) ){


### PR DESCRIPTION
fix bug(#3615 ):After the task is executed successfully, After the task is executed successfully, but the next task has not been submitted, stop the master，the workflow will fail