### PR TITLE
SECURITY: SONAR_TOKEN should be a secret

### DIFF
--- a/.github/workflows/ci_ut.yml
+++ b/.github/workflows/ci_ut.yml
@@ -81,7 +81,7 @@ jobs:
           -Dsonar.organization=apache
           -Dsonar.core.codeCoveragePlugin=jacoco
           -Dsonar.projectKey=apache-dolphinscheduler
-          -Dsonar.login=e4058004bc6be89decf558ac819aa1ecbee57682
+          -Dsonar.login="$SONAR_TOKEN"
           -Dsonar.exclusions=dolphinscheduler-ui/src/**/i18n/locale/*.js,dolphinscheduler-microbench/src/**/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The Sonar token was copy pasted plainly in the workflow file, this make use of the SONAR_TOKEN secret instead.

You (repository owners) will need to:
- create a new token on sonar
- set the new SONAR_TOKEN secret for the repository (or GitHub org)
- revoke the leaked token
