### PR TITLE
[Improvement][UI] download url resolve and security page disappear delay problem under GENERAL_USER

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/log.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/log.vue
@@ -169,7 +169,7 @@
        * Download log
        */
       _downloadLog () {
-        downloadFile('/dolphinscheduler/log/download-log', {
+        downloadFile('log/download-log', {
           taskInstanceId: this.stateId || this.logId
         })
       },

--- a/dolphinscheduler-ui/src/js/conf/home/pages/resource/pages/file/pages/details/index.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/resource/pages/file/pages/details/index.vue
@@ -87,7 +87,7 @@
         this.$router.go(-1)
       },
       _downloadFile () {
-        downloadFile('/dolphinscheduler/resources/download', {
+        downloadFile('resources/download', {
           id: this.$route.params.id
         })
       },

--- a/dolphinscheduler-ui/src/js/conf/home/pages/resource/pages/file/pages/list/_source/list.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/resource/pages/file/pages/list/_source/list.vue
@@ -162,7 +162,7 @@
         }
       },
       _downloadFile (item) {
-        downloadFile('/dolphinscheduler/resources/download', {
+        downloadFile('resources/download', {
           id: item.id
         })
       },

--- a/dolphinscheduler-ui/src/js/conf/home/pages/resource/pages/file/pages/subdirectory/_source/list.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/resource/pages/file/pages/subdirectory/_source/list.vue
@@ -163,7 +163,7 @@
         }
       },
       _downloadFile (item) {
-        downloadFile('/dolphinscheduler/resources/download', {
+        downloadFile('resources/download', {
           id: item.id
         })
       },

--- a/dolphinscheduler-ui/src/js/conf/home/pages/resource/pages/udf/pages/function/_source/list.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/resource/pages/udf/pages/function/_source/list.vue
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-v-ps<template>
+<template>
   <div class="list-model">
     <div class="table-box">
       <table class="fixed">

--- a/dolphinscheduler-ui/src/js/conf/home/pages/resource/pages/udf/pages/resource/_source/list.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/resource/pages/udf/pages/resource/_source/list.vue
@@ -143,7 +143,7 @@
     methods: {
       ...mapActions('resource', ['deleteResource']),
       _downloadFile (item) {
-        downloadFile('/dolphinscheduler/resources/download', {
+        downloadFile('resources/download', {
           id: item.id
         })
       },

--- a/dolphinscheduler-ui/src/js/conf/home/pages/resource/pages/udf/pages/subUdfDirectory/_source/list.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/resource/pages/udf/pages/subUdfDirectory/_source/list.vue
@@ -144,7 +144,7 @@
     methods: {
       ...mapActions('resource', ['deleteResource']),
       _downloadFile (item) {
-        downloadFile('/dolphinscheduler/resources/download', {
+        downloadFile('resources/download', {
           id: item.id
         })
       },

--- a/dolphinscheduler-ui/src/js/module/download/index.js
+++ b/dolphinscheduler-ui/src/js/module/download/index.js
@@ -16,12 +16,14 @@
  */
 
 import i18n from '@/module/i18n'
+import { resolveURL } from '@/module/io'
+
 /**
  * download file
  */
 const downloadFile = ($url, $obj) => {
   const param = {
-    url: $url,
+    url: resolveURL($url),
     obj: $obj
   }
 

--- a/dolphinscheduler-ui/src/js/module/permissions/index.js
+++ b/dolphinscheduler-ui/src/js/module/permissions/index.js
@@ -44,6 +44,7 @@ Permissions.prototype = {
           if ($(el).prop('tagName') === 'BUTTON') {
             $(el).attr('disabled', true)
           } else {
+            $(el).css('display', 'none')
             setTimeout(function () { el.parentNode.removeChild(el) }, 100)
           }
         }


### PR DESCRIPTION
## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

## What is the purpose of the pull request

UI Improvement

## Brief change log

 - *improvement: resovle download url with resolveURL to prevent change of apiPrefix*
 - *fix: security page disappear delay problem when force refresh under GENERAL_USER*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

 - just check new download url, and it's OK
 - just force refresh, the problem has been solved.