### PR TITLE
[Feature][API]enable response resources gzip compression

### DIFF
--- a/dolphinscheduler-api/src/main/resources/application-api.properties
+++ b/dolphinscheduler-api/src/main/resources/application-api.properties
@@ -32,6 +32,7 @@ spring.servlet.multipart.max-request-size=1024MB
 
 # enable response compression
 server.compression.enabled=true
+server.compression.mime-types=text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json,application/xml
 
 #post content
 server.jetty.max-http-post-size=5000000

--- a/dolphinscheduler-api/src/main/resources/application-api.properties
+++ b/dolphinscheduler-api/src/main/resources/application-api.properties
@@ -30,6 +30,9 @@ spring.jackson.time-zone=GMT+8
 spring.servlet.multipart.max-file-size=1024MB
 spring.servlet.multipart.max-request-size=1024MB
 
+# enable response compression
+server.compression.enabled=true
+
 #post content
 server.jetty.max-http-post-size=5000000
 


### PR DESCRIPTION
## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

## What is the purpose of the pull request

*enable response resources gzip compression*

- reduce response resources' transfer size
- improve access speed and user experience

## Brief change log

- *enable response resources gzip compression*

## Verify this pull request

This pull request is already covered by existing tests, such as *(please describe tests)*.

The screenshot of effect before the gzip compression is as follow:

![image](https://user-images.githubusercontent.com/4902714/100530165-74d38800-3229-11eb-976c-2984e84ec3b2.png)

The screenshot of effect after the gzip compression is as follow:

![image](https://user-images.githubusercontent.com/4902714/100530177-a0567280-3229-11eb-9f1f-aff5230c51a6.png)

![image](https://user-images.githubusercontent.com/4902714/100530179-a4829000-3229-11eb-881c-f608ce3cc5c2.png)
