### PR TITLE
[FIX-4135][worker]fix sqoop import hive error

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/sqoop/SqoopConstants.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/sqoop/SqoopConstants.java
@@ -57,6 +57,7 @@ public final class SqoopConstants {
 
     //sqoop hive
     public static final String HIVE_IMPORT = "--hive-import";
+    public static final String HIVE_DATABASE = "--hive-database";
     public static final String HIVE_TABLE = "--hive-table";
     public static final String CREATE_HIVE_TABLE = "--create-hive-table";
     public static final String HIVE_DROP_IMPORT_DELIMS = "--hive-drop-import-delims";

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/sqoop/generator/targets/HiveTargetGenerator.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/sqoop/generator/targets/HiveTargetGenerator.java
@@ -49,9 +49,10 @@ public class HiveTargetGenerator implements ITargetGenerator {
 
                 if (StringUtils.isNotEmpty(targetHiveParameter.getHiveDatabase())
                     && StringUtils.isNotEmpty(targetHiveParameter.getHiveTable())) {
-                    hiveTargetSb.append(Constants.SPACE).append(SqoopConstants.HIVE_TABLE)
-                        .append(Constants.SPACE).append(String.format("%s.%s", targetHiveParameter.getHiveDatabase(),
-                        targetHiveParameter.getHiveTable()));
+                    hiveTargetSb.append(Constants.SPACE).append(SqoopConstants.HIVE_DATABASE)
+                        .append(Constants.SPACE).append(targetHiveParameter.getHiveDatabase())
+                        .append(Constants.SPACE).append(SqoopConstants.HIVE_TABLE)
+                        .append(Constants.SPACE).append(targetHiveParameter.getHiveTable());
                 }
 
                 if (targetHiveParameter.isCreateHiveTable()) {

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/worker/task/sqoop/SqoopTaskTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/worker/task/sqoop/SqoopTaskTest.java
@@ -144,7 +144,7 @@ public class SqoopTaskTest {
         String mysqlToHiveScript = generator.generateSqoopJob(mysqlToHiveParams, mysqlTaskExecutionContext);
         String mysqlToHiveExpected =
             "sqoop import -D mapred.job.name=sqoop_import -m 1 --connect \"jdbc:mysql://192.168.0.111:3306/test\" --username kylo --password \"123456\" "
-                + "--query \"SELECT * FROM person_2 WHERE \\$CONDITIONS\" --map-column-java id=Integer --hive-import --hive-table stg.person_internal_2 "
+                + "--query \"SELECT * FROM person_2 WHERE \\$CONDITIONS\" --map-column-java id=Integer --hive-import --hive-database stg --hive-table person_internal_2 "
                 + "--create-hive-table --hive-overwrite --delete-target-dir --hive-partition-key date --hive-partition-value 2020-02-16";
         Assert.assertEquals(mysqlToHiveExpected, mysqlToHiveScript);
 


### PR DESCRIPTION
## What is the purpose of the pull request

*#4135 split hive database and table when RMDBS improt to HIve*

## Brief change log
  - *Modify Sqoop HiveTargetGenerator.class*

## Verify this pull request

This pull request is already covered by existing tests, such as *worker/SqoopTaskTest*.
