### PR TITLE
[Fix-4144][jar upgrade]upgrade jackson version to 2.9.10

### DIFF
--- a/dolphinscheduler-dist/release-docs/LICENSE
+++ b/dolphinscheduler-dist/release-docs/LICENSE
@@ -343,8 +343,8 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     opencsv 2.3: https://mvnrepository.com/artifact/net.sf.opencsv/opencsv/2.3, Apache 2.0
     parquet-hadoop-bundle 1.8.1: https://mvnrepository.com/artifact/org.apache.parquet/parquet-hadoop-bundle/1.8.1, Apache 2.0
     poi 3.17: https://mvnrepository.com/artifact/org.apache.poi/poi/3.17, Apache 2.0
-    quartz 2.2.3: https://mvnrepository.com/artifact/org.quartz-scheduler/quartz/2.2.3, Apache 2.0
-    quartz-jobs 2.2.3: https://mvnrepository.com/artifact/org.quartz-scheduler/quartz-jobs/2.2.3, Apache 2.0
+    quartz 2.3.0: https://mvnrepository.com/artifact/org.quartz-scheduler/quartz/2.3.0, Apache 2.0
+    quartz-jobs 2.3.0: https://mvnrepository.com/artifact/org.quartz-scheduler/quartz-jobs/2.3.0, Apache 2.0
     snakeyaml 1.23: https://mvnrepository.com/artifact/org.yaml/snakeyaml/1.23, Apache 2.0
     snappy 0.2: https://mvnrepository.com/artifact/org.iq80.snappy/snappy/0.2, Apache 2.0
     snappy-java 1.0.4.1: https://github.com/xerial/snappy-java, Apache 2.0

--- a/dolphinscheduler-dist/release-docs/LICENSE
+++ b/dolphinscheduler-dist/release-docs/LICENSE
@@ -385,7 +385,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     xml-apis 1.4.01: https://mvnrepository.com/artifact/xml-apis/xml-apis/1.4.01, Apache 2.0 and W3C
     zookeeper 3.4.14: https://mvnrepository.com/artifact/org.apache.zookeeper/zookeeper/3.4.14, Apache 2.0
     presto-jdbc 0.238.1 https://mvnrepository.com/artifact/com.facebook.presto/presto-jdbc/0.238.1
-
+    HikariCP-java6 2.3.13: https://mvnrepository.com/artifact/com.zaxxer/HikariCP-java6/2.3.13, Apache 2.0
 
 ========================================================================
 BSD licenses
@@ -445,6 +445,8 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     oshi-core 3.5.0: https://mvnrepository.com/artifact/com.github.oshi/oshi-core/3.5.0, EPL 1.0
     junit 4.12: https://mvnrepository.com/artifact/junit/junit/4.12, EPL 1.0
     h2-1.4.200 https://github.com/h2database/h2database/blob/master/LICENSE.txt, MPL 2.0 or EPL 1.0
+    mchange-commons-java 0.2.11: https://mvnrepository.com/artifact/com.mchange/mchange-commons-java/0.2.11, EPL 1.0
+    c3p0 0.9.5.2: https://mvnrepository.com/artifact/com.mchange/c3p0/0.9.5.2, EPL 1.0
 
 ========================================================================
 MIT licenses

--- a/dolphinscheduler-dist/release-docs/LICENSE
+++ b/dolphinscheduler-dist/release-docs/LICENSE
@@ -287,15 +287,15 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     httpclient 4.4.1: https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient/4.4.1, Apache 2.0
     httpcore 4.4.1: https://mvnrepository.com/artifact/org.apache.httpcomponents/httpcore/4.4.1, Apache 2.0
     httpmime 4.5.7: https://mvnrepository.com/artifact/org.apache.httpcomponents/httpmime/4.5.7, Apache 2.0
-    jackson-annotations 2.9.8: https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations/2.9.8, Apache 2.0
-    jackson-core 2.9.8: https://github.com/FasterXML/jackson-core, Apache 2.0
+    jackson-annotations 2.9.10: https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations/2.9.10, Apache 2.0
+    jackson-core 2.9.10: https://github.com/FasterXML/jackson-core, Apache 2.0
     jackson-core-asl 1.9.13: https://mvnrepository.com/artifact/org.codehaus.jackson/jackson-core-asl/1.9.13, Apache 2.0
-    jackson-databind 2.9.8: https://github.com/FasterXML/jackson-databind, Apache 2.0
-    jackson-datatype-jdk8 2.9.8: https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.9.8, Apache 2.0
-    jackson-datatype-jsr310 2.9.8: https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.9.8, Apache 2.0
+    jackson-databind 2.9.10: https://github.com/FasterXML/jackson-databind, Apache 2.0
+    jackson-datatype-jdk8 2.9.10: https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.9.10, Apache 2.0
+    jackson-datatype-jsr310 2.9.10: https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.9.10, Apache 2.0
     jackson-jaxrs 1.9.13: https://mvnrepository.com/artifact/org.codehaus.jackson/jackson-jaxrs/1.9.13, Apache 2.0 and LGPL 2.1
     jackson-mapper-asl 1.9.13: https://mvnrepository.com/artifact/org.codehaus.jackson/jackson-mapper-asl/1.9.13, Apache 2.0
-    jackson-module-parameter-names 2.9.8: https://mvnrepository.com/artifact/com.fasterxml.jackson.module/jackson-module-parameter-names/2.9.8, Apache 2.0
+    jackson-module-parameter-names 2.9.10: https://mvnrepository.com/artifact/com.fasterxml.jackson.module/jackson-module-parameter-names/2.9.10, Apache 2.0
     jackson-xc 1.9.13: https://mvnrepository.com/artifact/org.codehaus.jackson/jackson-xc/1.9.13, Apache 2.0 and LGPL 2.1
     javax.inject 1: https://mvnrepository.com/artifact/javax.inject/javax.inject/1, Apache 2.0
     javax.jdo-3.2.0-m3: https://mvnrepository.com/artifact/org.datanucleus/javax.jdo/3.2.0-m3, Apache 2.0

--- a/dolphinscheduler-dist/release-docs/licenses/LICENSE-HikariCP-java6.txt
+++ b/dolphinscheduler-dist/release-docs/licenses/LICENSE-HikariCP-java6.txt
@@ -1,0 +1,191 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification within
+third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/dolphinscheduler-dist/release-docs/licenses/LICENSE-c3p0.txt
+++ b/dolphinscheduler-dist/release-docs/licenses/LICENSE-c3p0.txt
@@ -1,0 +1,213 @@
+Eclipse Public License - v 1.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC 
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM 
+CONSTITUTES RECIPIENT’S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+a) in the case of the initial Contributor, the initial code and documentation 
+   distributed under this Agreement, and
+
+b) in the case of each subsequent Contributor:
+
+    i) changes to the Program, and
+
+   ii) additions to the Program;
+
+where such changes and/or additions to the Program originate from and are 
+distributed by that particular Contributor. A Contribution 'originates' from 
+a Contributor if it was added to the Program by such Contributor itself or 
+anyone acting on such Contributor’s behalf. Contributions do not include 
+additionsto the Program which: (i) are separate modules of software distributed
+in conjunction with the Program under their own license agreement, and (ii) are 
+not derivative works of the Program.
+
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents " mean patent claims licensable by a Contributor which are 
+necessarily infringed by the use or sale of its Contribution alone or when 
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement, 
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+a) Subject to the terms of this Agreement, each Contributor hereby grants 
+Recipient a non-exclusive, worldwide, royalty-free copyright license to 
+reproduce, prepare derivative works of, publicly display, publicly perform, 
+distribute and sublicense the Contribution of such Contributor, if any, and such 
+derivative works, in source code and object code form.
+
+b) Subject to the terms of this Agreement, each Contributor hereby grants 
+Recipient a non-exclusive, worldwide, royalty-free patent license under 
+Licensed Patents to make, use, sell, offer to sell, import and otherwise 
+transfer the Contribution of such Contributor, if any, in source code and 
+object code form. This patent license shall apply to the combination of the 
+Contribution and the Program if, at the time the Contribution is added by the 
+Contributor, such addition of the Contribution causes such combination to be 
+covered by the Licensed Patents. The patent license shall not apply to any 
+other combinations which include the Contribution. No hardware per se is 
+licensed hereunder.
+
+c) Recipient understands that although each Contributor grants the licenses to 
+its Contributions set forth herein, no assurances are provided by any 
+Contributor that the Program does not infringe the patent or other intellectual
+property rights of any other entity. Each Contributor disclaims any liability 
+to Recipient for claims brought by any other entity based on infringement of 
+intellectual property rights or otherwise. As a condition to exercising the 
+rights and licenses granted hereunder, each Recipient hereby assumes sole 
+responsibility to secure any other intellectual property rights needed, if any. 
+For example, if a third party patent license is required to allow Recipient to 
+distribute the Program, it is Recipient’s responsibility to acquire that 
+license before distributing the Program.
+
+d) Each Contributor represents that to its knowledge it has sufficient 
+copyright rights in its Contribution, if any, to grant the copyright license 
+set forth in this Agreement.
+
+3. REQUIREMENTS
+
+A Contributor may choose to distribute the Program in object code form under 
+its own license agreement, provided that:
+
+a) it complies with the terms and conditions of this Agreement; and
+
+b) its license agreement:
+
+     i) effectively disclaims on behalf of all Contributors all warranties and 
+        conditions, express and implied, including warranties or conditions of 
+        title and non-infringement, and implied warranties or conditions of 
+        merchantability and fitness for a particular purpose;
+
+    ii) effectively excludes on behalf of all Contributors all liability for 
+        damages, including direct, indirect, special, incidental and 
+        consequential damages, such as lost profits;
+
+   iii) states that any provisions which differ from this Agreement are 
+        offered by that Contributor alone and not by any other party; and
+
+    iv) states that source code for the Program is available from such 
+        Contributor, and informs licensees how to obtain it in a reasonable 
+        manner on or through a medium customarily used for software exchange.
+
+When the Program is made available in source code form:
+
+a) it must be made available under this Agreement; and
+
+b) a copy of this Agreement must be included with each copy of the Program.
+
+Contributors may not remove or alter any copyright notices contained within 
+the Program.
+
+Each Contributor must identify itself as the originator of its Contribution, 
+if any, in a manner that reasonably allows subsequent Recipients to identify 
+the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities with 
+respect to end users, business partners and the like. While this license is 
+intended to facilitate the commercial use of the Program, the Contributor who 
+includes the Program in a commercial product offering should do so in a manner 
+which does not create potential liability for other Contributors. Therefore, 
+if a Contributor includes the Program in a commercial product offering, such 
+Contributor ("Commercial Contributor") hereby agrees to defend and indemnify 
+every other Contributor ("Indemnified Contributor") against any losses, damages 
+and costs (collectively "Losses") arising from claims, lawsuits and other legal 
+actions brought by a third party against the Indemnified Contributor to the 
+extent caused by the acts or omissions of such Commercial Contributor in 
+connection with its distribution of the Program in a commercial product 
+offering. The obligations in this section do not apply to any claims or Losses 
+relating to any actual or alleged intellectual property infringement. In order 
+to qualify, an Indemnified Contributor must: a) promptly notify the Commercial 
+Contributor in writing of such claim, and b) allow the Commercial Contributor 
+to control, and cooperate with the Commercial Contributor in, the defense and 
+any related settlement negotiations. The Indemnified Contributor may participate 
+in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product 
+offering, Product X. That Contributor is then a Commercial Contributor. If that 
+Commercial Contributor then makes performance claims, or offers warranties 
+related to Product X, those performance claims and warranties are such 
+Commercial Contributor’s responsibility alone. Under this section, the 
+Commercial Contributor would have to defend claims against the other 
+Contributors related to those performance claims and warranties, and if a court 
+requires any other Contributor to pay any damages as a result, the Commercial 
+Contributor must pay those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN 
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR 
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, 
+NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each 
+Recipient is solely responsible for determining the appropriateness of using 
+and distributing the Program and assumes all risks associated with its 
+exercise of rights under this Agreement , including but not limited to the 
+risks and costs of program errors, compliance with applicable laws, damage to 
+or loss of data, programs or equipment, and unavailability or interruption of 
+operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY 
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST 
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY 
+WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS 
+GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under applicable 
+law, it shall not affect the validity or enforceability of the remainder of the 
+terms of this Agreement, and without further action by the parties hereto, such 
+provision shall be reformed to the minimum extent necessary to make such 
+provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a 
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself 
+(excluding combinations of the Program with other software or hardware) 
+infringes such Recipient’s patent(s), then such Recipient’s rights granted 
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient’s rights under this Agreement shall terminate if it fails to 
+comply with any of the material terms or conditions of this Agreement and does 
+not cure such failure in a reasonable period of time after becoming aware of 
+such noncompliance. If all Recipient’s rights under this Agreement terminate, 
+Recipient agrees to cease use and distribution of the Program as soon as 
+reasonably practicable. However, Recipient’s obligations under this Agreement 
+and any licenses granted by Recipient relating to the Program shall continue 
+and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in 
+order to avoid inconsistency the Agreement is copyrighted and may only be 
+modified in the following manner. The Agreement Steward reserves the right to 
+publish new versions (including revisions) of this Agreement from time to time. 
+No one other than the Agreement Steward has the right to modify this Agreement. 
+The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation 
+may assign the responsibility to serve as the Agreement Steward to a suitable 
+separate entity. Each new version of the Agreement will be given a 
+distinguishing version number. The Program (including Contributions) may always 
+be distributed subject to the version of the Agreement under which it was 
+received. In addition, after a new version of the Agreement is published, 
+Contributor may elect to distribute the Program (including its Contributions) 
+under the new version. Except as expressly stated in Sections 2(a) and 2(b) 
+above, Recipient receives no rights or licenses to the intellectual property of 
+any Contributor under this Agreement, whether expressly, by implication, 
+estoppel or otherwise. All rights in the Program not expressly granted under 
+this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the 
+intellectual property laws of the United States of America. No party to this 
+Agreement will bring a legal action under this Agreement more than one year 
+after the cause of action arose. Each party waives its rights to a jury trial 
+in any resulting litigation.
+

--- a/dolphinscheduler-dist/release-docs/licenses/LICENSE-mchange-commons-java.txt
+++ b/dolphinscheduler-dist/release-docs/licenses/LICENSE-mchange-commons-java.txt
@@ -1,0 +1,213 @@
+Eclipse Public License - v 1.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC 
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM 
+CONSTITUTES RECIPIENT’S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+a) in the case of the initial Contributor, the initial code and documentation 
+   distributed under this Agreement, and
+
+b) in the case of each subsequent Contributor:
+
+    i) changes to the Program, and
+
+   ii) additions to the Program;
+
+where such changes and/or additions to the Program originate from and are 
+distributed by that particular Contributor. A Contribution 'originates' from 
+a Contributor if it was added to the Program by such Contributor itself or 
+anyone acting on such Contributor’s behalf. Contributions do not include 
+additionsto the Program which: (i) are separate modules of software distributed
+in conjunction with the Program under their own license agreement, and (ii) are 
+not derivative works of the Program.
+
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents " mean patent claims licensable by a Contributor which are 
+necessarily infringed by the use or sale of its Contribution alone or when 
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement, 
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+a) Subject to the terms of this Agreement, each Contributor hereby grants 
+Recipient a non-exclusive, worldwide, royalty-free copyright license to 
+reproduce, prepare derivative works of, publicly display, publicly perform, 
+distribute and sublicense the Contribution of such Contributor, if any, and such 
+derivative works, in source code and object code form.
+
+b) Subject to the terms of this Agreement, each Contributor hereby grants 
+Recipient a non-exclusive, worldwide, royalty-free patent license under 
+Licensed Patents to make, use, sell, offer to sell, import and otherwise 
+transfer the Contribution of such Contributor, if any, in source code and 
+object code form. This patent license shall apply to the combination of the 
+Contribution and the Program if, at the time the Contribution is added by the 
+Contributor, such addition of the Contribution causes such combination to be 
+covered by the Licensed Patents. The patent license shall not apply to any 
+other combinations which include the Contribution. No hardware per se is 
+licensed hereunder.
+
+c) Recipient understands that although each Contributor grants the licenses to 
+its Contributions set forth herein, no assurances are provided by any 
+Contributor that the Program does not infringe the patent or other intellectual
+property rights of any other entity. Each Contributor disclaims any liability 
+to Recipient for claims brought by any other entity based on infringement of 
+intellectual property rights or otherwise. As a condition to exercising the 
+rights and licenses granted hereunder, each Recipient hereby assumes sole 
+responsibility to secure any other intellectual property rights needed, if any. 
+For example, if a third party patent license is required to allow Recipient to 
+distribute the Program, it is Recipient’s responsibility to acquire that 
+license before distributing the Program.
+
+d) Each Contributor represents that to its knowledge it has sufficient 
+copyright rights in its Contribution, if any, to grant the copyright license 
+set forth in this Agreement.
+
+3. REQUIREMENTS
+
+A Contributor may choose to distribute the Program in object code form under 
+its own license agreement, provided that:
+
+a) it complies with the terms and conditions of this Agreement; and
+
+b) its license agreement:
+
+     i) effectively disclaims on behalf of all Contributors all warranties and 
+        conditions, express and implied, including warranties or conditions of 
+        title and non-infringement, and implied warranties or conditions of 
+        merchantability and fitness for a particular purpose;
+
+    ii) effectively excludes on behalf of all Contributors all liability for 
+        damages, including direct, indirect, special, incidental and 
+        consequential damages, such as lost profits;
+
+   iii) states that any provisions which differ from this Agreement are 
+        offered by that Contributor alone and not by any other party; and
+
+    iv) states that source code for the Program is available from such 
+        Contributor, and informs licensees how to obtain it in a reasonable 
+        manner on or through a medium customarily used for software exchange.
+
+When the Program is made available in source code form:
+
+a) it must be made available under this Agreement; and
+
+b) a copy of this Agreement must be included with each copy of the Program.
+
+Contributors may not remove or alter any copyright notices contained within 
+the Program.
+
+Each Contributor must identify itself as the originator of its Contribution, 
+if any, in a manner that reasonably allows subsequent Recipients to identify 
+the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities with 
+respect to end users, business partners and the like. While this license is 
+intended to facilitate the commercial use of the Program, the Contributor who 
+includes the Program in a commercial product offering should do so in a manner 
+which does not create potential liability for other Contributors. Therefore, 
+if a Contributor includes the Program in a commercial product offering, such 
+Contributor ("Commercial Contributor") hereby agrees to defend and indemnify 
+every other Contributor ("Indemnified Contributor") against any losses, damages 
+and costs (collectively "Losses") arising from claims, lawsuits and other legal 
+actions brought by a third party against the Indemnified Contributor to the 
+extent caused by the acts or omissions of such Commercial Contributor in 
+connection with its distribution of the Program in a commercial product 
+offering. The obligations in this section do not apply to any claims or Losses 
+relating to any actual or alleged intellectual property infringement. In order 
+to qualify, an Indemnified Contributor must: a) promptly notify the Commercial 
+Contributor in writing of such claim, and b) allow the Commercial Contributor 
+to control, and cooperate with the Commercial Contributor in, the defense and 
+any related settlement negotiations. The Indemnified Contributor may participate 
+in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product 
+offering, Product X. That Contributor is then a Commercial Contributor. If that 
+Commercial Contributor then makes performance claims, or offers warranties 
+related to Product X, those performance claims and warranties are such 
+Commercial Contributor’s responsibility alone. Under this section, the 
+Commercial Contributor would have to defend claims against the other 
+Contributors related to those performance claims and warranties, and if a court 
+requires any other Contributor to pay any damages as a result, the Commercial 
+Contributor must pay those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN 
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR 
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, 
+NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each 
+Recipient is solely responsible for determining the appropriateness of using 
+and distributing the Program and assumes all risks associated with its 
+exercise of rights under this Agreement , including but not limited to the 
+risks and costs of program errors, compliance with applicable laws, damage to 
+or loss of data, programs or equipment, and unavailability or interruption of 
+operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY 
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST 
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY 
+WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS 
+GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under applicable 
+law, it shall not affect the validity or enforceability of the remainder of the 
+terms of this Agreement, and without further action by the parties hereto, such 
+provision shall be reformed to the minimum extent necessary to make such 
+provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a 
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself 
+(excluding combinations of the Program with other software or hardware) 
+infringes such Recipient’s patent(s), then such Recipient’s rights granted 
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient’s rights under this Agreement shall terminate if it fails to 
+comply with any of the material terms or conditions of this Agreement and does 
+not cure such failure in a reasonable period of time after becoming aware of 
+such noncompliance. If all Recipient’s rights under this Agreement terminate, 
+Recipient agrees to cease use and distribution of the Program as soon as 
+reasonably practicable. However, Recipient’s obligations under this Agreement 
+and any licenses granted by Recipient relating to the Program shall continue 
+and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in 
+order to avoid inconsistency the Agreement is copyrighted and may only be 
+modified in the following manner. The Agreement Steward reserves the right to 
+publish new versions (including revisions) of this Agreement from time to time. 
+No one other than the Agreement Steward has the right to modify this Agreement. 
+The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation 
+may assign the responsibility to serve as the Agreement Steward to a suitable 
+separate entity. Each new version of the Agreement will be given a 
+distinguishing version number. The Program (including Contributions) may always 
+be distributed subject to the version of the Agreement under which it was 
+received. In addition, after a new version of the Agreement is published, 
+Contributor may elect to distribute the Program (including its Contributions) 
+under the new version. Except as expressly stated in Sections 2(a) and 2(b) 
+above, Recipient receives no rights or licenses to the intellectual property of 
+any Contributor under this Agreement, whether expressly, by implication, 
+estoppel or otherwise. All rights in the Program not expressly granted under 
+this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the 
+intellectual property laws of the United States of America. No party to this 
+Agreement will bring a legal action under this Agreement more than one year 
+after the cause of action arose. Each party waives its rights to a jury trial 
+in any resulting litigation.
+

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <logback.version>1.2.3</logback.version>
         <hadoop.version>2.7.3</hadoop.version>
         <quartz.version>2.3.0</quartz.version>
-        <jackson.version>2.9.8</jackson.version>
+        <jackson.version>2.9.10</jackson.version>
         <mybatis-plus.version>3.2.0</mybatis-plus.version>
         <mybatis.spring.version>2.0.1</mybatis.spring.version>
         <cron.utils.version>5.0.5</cron.utils.version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <java.version>1.8</java.version>
         <logback.version>1.2.3</logback.version>
         <hadoop.version>2.7.3</hadoop.version>
-        <quartz.version>2.2.3</quartz.version>
+        <quartz.version>2.3.0</quartz.version>
         <jackson.version>2.9.8</jackson.version>
         <mybatis-plus.version>3.2.0</mybatis-plus.version>
         <mybatis.spring.version>2.0.1</mybatis.spring.version>

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -211,3 +211,7 @@ xz-1.0.jar
 zookeeper-3.4.14.jar
 guava-retrying-2.0.0.jar
 presto-jdbc-0.238.1.jar
+HikariCP-java6-2.3.13.jar
+mchange-commons-java-0.2.11.jar
+c3p0-0.9.5.2.jar
+

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -78,10 +78,10 @@ htrace-core-3.1.0-incubating.jar
 httpclient-4.4.1.jar
 httpcore-4.4.1.jar
 httpmime-4.5.12.jar
-jackson-annotations-2.9.8.jar
-jackson-core-2.9.8.jar
+jackson-annotations-2.9.10.jar
+jackson-core-2.9.10.jar
 jackson-core-asl-1.9.13.jar
-jackson-databind-2.9.8.jar
+jackson-databind-2.9.10.jar
 jackson-datatype-jdk8-2.9.10.jar
 jackson-datatype-jsr310-2.9.10.jar
 jackson-jaxrs-1.9.13.jar

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -163,8 +163,8 @@ parquet-hadoop-bundle-1.8.1.jar
 poi-3.17.jar
 postgresql-42.1.4.jar
 protobuf-java-2.5.0.jar
-quartz-2.2.3.jar
-quartz-jobs-2.2.3.jar
+quartz-2.3.0.jar
+quartz-jobs-2.3.0.jar
 slf4j-api-1.7.5.jar
 snakeyaml-1.23.jar
 snappy-0.2.jar


### PR DESCRIPTION
## What is the purpose of the pull request
[4144](https://github.com/apache/incubator-dolphinscheduler/issues/4144)

There is a vulnerability in jackson-databind 2.9.8 ,upgrade recommended

## Brief change log
Modify the corresponding jar version in the incubator-dolphinscheduler/pom.xml.
Modify the version of the corresponding jar in tools/dependencies/known-dependencies.txt.
Modify the relevant jar version in the dolphinscheduler-dist/release-docs/LICENSE file.


