### PR TITLE
[Feature][Dao] Execute sql from the latest image version not earliest to current version

### DIFF
--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/upgrade/DolphinSchedulerManager.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/upgrade/DolphinSchedulerManager.java
@@ -16,12 +16,12 @@
  */
 package org.apache.dolphinscheduler.dao.upgrade;
 
+import java.util.List;
+
 import org.apache.dolphinscheduler.common.enums.DbType;
 import org.apache.dolphinscheduler.common.utils.SchemaUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
 
 /**
  * upgrade manager
@@ -109,7 +109,7 @@ public class DolphinSchedulerManager {
             }
             // The target version of the upgrade
             String schemaVersion = "";
-            for(String schemaDir : schemaList) {
+			String schemaDir = schemaList.get(schemaList.size() - 1);
                 schemaVersion = schemaDir.split("_")[0];
                 if(SchemaUtils.isAGreatVersion(schemaVersion , version)) {
                     logger.info("upgrade DolphinScheduler metadata version from {} to {}", version, schemaVersion);
@@ -118,10 +118,9 @@ public class DolphinSchedulerManager {
                     if ("1.3.0".equals(schemaVersion)) {
                         upgradeDao.upgradeDolphinSchedulerWorkerGroup();
                     }
-                    version = schemaVersion;
+				version = schemaVersion;
                 }
-
-            }
+			
         }
 
         // Assign the value of the version field in the version table to the version of the product

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/upgrade/DolphinSchedulerManager.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/upgrade/DolphinSchedulerManager.java
@@ -110,16 +110,16 @@ public class DolphinSchedulerManager {
             // The target version of the upgrade
             String schemaVersion = "";
 			String schemaDir = schemaList.get(schemaList.size() - 1);
-                schemaVersion = schemaDir.split("_")[0];
-                if(SchemaUtils.isAGreatVersion(schemaVersion , version)) {
-                    logger.info("upgrade DolphinScheduler metadata version from {} to {}", version, schemaVersion);
-                    logger.info("Begin upgrading DolphinScheduler's table structure");
-                    upgradeDao.upgradeDolphinScheduler(schemaDir);
-                    if ("1.3.0".equals(schemaVersion)) {
-                        upgradeDao.upgradeDolphinSchedulerWorkerGroup();
-                    }
+			schemaVersion = schemaDir.split("_")[0];
+			if (SchemaUtils.isAGreatVersion(schemaVersion, version)) {
+				logger.info("upgrade DolphinScheduler metadata version from {} to {}", version, schemaVersion);
+				logger.info("Begin upgrading DolphinScheduler's table structure");
+				upgradeDao.upgradeDolphinScheduler(schemaDir);
+				if ("1.3.0".equals(schemaVersion)) {
+					upgradeDao.upgradeDolphinSchedulerWorkerGroup();
+				}
 				version = schemaVersion;
-                }
+			}
 			
         }
 

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/upgrade/DolphinSchedulerManager.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/upgrade/DolphinSchedulerManager.java
@@ -16,12 +16,12 @@
  */
 package org.apache.dolphinscheduler.dao.upgrade;
 
-import java.util.List;
-
 import org.apache.dolphinscheduler.common.enums.DbType;
 import org.apache.dolphinscheduler.common.utils.SchemaUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 /**
  * upgrade manager
@@ -109,18 +109,18 @@ public class DolphinSchedulerManager {
             }
             // The target version of the upgrade
             String schemaVersion = "";
-			String schemaDir = schemaList.get(schemaList.size() - 1);
-			schemaVersion = schemaDir.split("_")[0];
-			if (SchemaUtils.isAGreatVersion(schemaVersion, version)) {
-				logger.info("upgrade DolphinScheduler metadata version from {} to {}", version, schemaVersion);
-				logger.info("Begin upgrading DolphinScheduler's table structure");
-				upgradeDao.upgradeDolphinScheduler(schemaDir);
-				if ("1.3.0".equals(schemaVersion)) {
-					upgradeDao.upgradeDolphinSchedulerWorkerGroup();
-				}
-				version = schemaVersion;
-			}
-			
+            String schemaDir = schemaList.get(schemaList.size() - 1);
+                schemaVersion = schemaDir.split("_")[0];
+                if(SchemaUtils.isAGreatVersion(schemaVersion , version)) {
+                    logger.info("upgrade DolphinScheduler metadata version from {} to {}", version, schemaVersion);
+                    logger.info("Begin upgrading DolphinScheduler's table structure");
+                    upgradeDao.upgradeDolphinScheduler(schemaDir);
+                    if ("1.3.0".equals(schemaVersion)) {
+                        upgradeDao.upgradeDolphinSchedulerWorkerGroup();
+                    }
+                    version = schemaVersion;
+                }
+
         }
 
         // Assign the value of the version field in the version table to the version of the product

--- a/sql/create/release-1.0.0_schema/mysql/dolphinscheduler_ddl.sql
+++ b/sql/create/release-1.0.0_schema/mysql/dolphinscheduler_ddl.sql
@@ -193,8 +193,8 @@ CREATE TABLE `t_escheduler_project` (
   `desc` varchar(200) DEFAULT NULL COMMENT 'project description',
   `user_id` int(11) DEFAULT NULL COMMENT 'creator id',
   `flag` tinyint(4) DEFAULT '1' COMMENT '0 not available, 1 available',
-  `create_time` datetime DEFAULT CURRENT_TIMESTAMP COMMENT 'create time',
-  `update_time` datetime DEFAULT CURRENT_TIMESTAMP COMMENT 'update time',
+  `create_time` datetime DEFAULT NULL COMMENT 'create time',
+  `update_time` datetime DEFAULT NULL COMMENT 'update time',
   PRIMARY KEY (`id`),
   KEY `user_id_index` (`user_id`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/sql/dolphinscheduler_mysql.sql
+++ b/sql/dolphinscheduler_mysql.sql
@@ -479,8 +479,8 @@ CREATE TABLE `t_ds_project` (
   `description` varchar(200) DEFAULT NULL,
   `user_id` int(11) DEFAULT NULL COMMENT 'creator id',
   `flag` tinyint(4) DEFAULT '1' COMMENT '0 not available, 1 available',
-  `create_time` datetime DEFAULT CURRENT_TIMESTAMP COMMENT 'create time',
-  `update_time` datetime DEFAULT CURRENT_TIMESTAMP COMMENT 'update time',
+  `create_time` datetime DEFAULT NULL COMMENT 'create time',
+  `update_time` datetime DEFAULT NULL COMMENT 'update time',
   PRIMARY KEY (`id`),
   KEY `user_id_index` (`user_id`) USING BTREE
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;

--- a/sql/upgrade/1.0.2_schema/mysql/dolphinscheduler_ddl.sql
+++ b/sql/upgrade/1.0.2_schema/mysql/dolphinscheduler_ddl.sql
@@ -97,9 +97,9 @@ CREATE PROCEDURE ac_escheduler_T_t_escheduler_error_command()
            `failure_strategy` tinyint(4) NULL DEFAULT 0 COMMENT 'failure strategy',
            `warning_type` tinyint(4) NULL DEFAULT 0 COMMENT 'warning type',
            `warning_group_id` int(11) NULL DEFAULT NULL COMMENT 'warning group id',
-           `schedule_time` datetime(0) NULL DEFAULT NULL COMMENT 'scheduler time',
-           `start_time` datetime(0) NULL DEFAULT NULL COMMENT 'start time',
-           `update_time` datetime(0) NULL DEFAULT NULL COMMENT 'update time',
+           `schedule_time` datetime NULL DEFAULT NULL COMMENT 'scheduler time',
+           `start_time` datetime NULL DEFAULT NULL COMMENT 'start time',
+           `update_time` datetime NULL DEFAULT NULL COMMENT 'update time',
            `dependence` text CHARACTER SET utf8 COLLATE utf8_general_ci NULL COMMENT 'dependence',
            `process_instance_priority` int(11) NULL DEFAULT NULL COMMENT 'process instance priority, 0 Highest,1 High,2 Medium,3 Low,4 Lowest',
            `worker_group_id` int(11) NULL DEFAULT -1 COMMENT 'worker group id',
@@ -125,8 +125,8 @@ CREATE PROCEDURE ac_escheduler_T_t_escheduler_worker_group()
            `id` bigint(11) NOT NULL AUTO_INCREMENT COMMENT 'id',
            `name` varchar(256)  NULL DEFAULT NULL COMMENT 'worker group name',
            `ip_list` varchar(256)  NULL DEFAULT NULL COMMENT 'worker ip list. split by [,] ',
-           `create_time` datetime(0) NULL DEFAULT NULL COMMENT 'create time',
-           `update_time` datetime(0) NULL DEFAULT NULL COMMENT 'update time',
+           `create_time` datetime NULL DEFAULT NULL COMMENT 'create time',
+           `update_time` datetime NULL DEFAULT NULL COMMENT 'update time',
            PRIMARY KEY (`id`) USING BTREE
        ) ENGINE = InnoDB AUTO_INCREMENT=1 CHARACTER SET = utf8 COLLATE = utf8_general_ci ROW_FORMAT = Dynamic;
 


### PR DESCRIPTION
## What is the purpose of the pull request

*Fixes this [issue](https://github.com/apache/incubator-dolphinscheduler/issues/3801)*

## Brief change log
*DolphinSchedulerManager.java*

  - *Obtained the last most up-to-date version from the schemaList so that when updating it updates to  that version instead of updating from the earliest version to the recent versions from schemaLisT*
