### PR TITLE
[Fix-3457][flink] fix flink args build problem

### DIFF
--- a/dolphinscheduler-api/src/main/resources/application-api.properties
+++ b/dolphinscheduler-api/src/main/resources/application-api.properties
@@ -35,7 +35,7 @@ server.compression.enabled=true
 server.compression.mime-types=text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json,application/xml
 
 #post content
-server.jetty.max-http-post-size=5000000
+server.jetty.max-http-form-post-size=5000000
 
 spring.messages.encoding=UTF-8
 

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/Constants.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/Constants.java
@@ -605,12 +605,6 @@ public final class Constants {
 
 
     /**
-     * --queue --qu
-     */
-    public static final String FLINK_QUEUE = "--qu";
-
-
-    /**
      * exit code success
      */
     public static final int EXIT_CODE_SUCCESS = 0;
@@ -838,6 +832,7 @@ public final class Constants {
     public static final String FLINK_RUN_MODE = "-m";
     public static final String FLINK_YARN_SLOT = "-ys";
     public static final String FLINK_APP_NAME = "-ynm";
+    public static final String FLINK_QUEUE = "-yqu";
     public static final String FLINK_TASK_MANAGE = "-yn";
 
     public static final String FLINK_JOB_MANAGE_MEM = "-yjm";

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/FlinkArgsUtils.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/FlinkArgsUtils.java
@@ -47,6 +47,7 @@ public class FlinkArgsUtils {
         if (StringUtils.isNotEmpty(tmpDeployMode)) {
             deployMode = tmpDeployMode;
         }
+        String others = param.getOthers();
         if (!LOCAL_DEPLOY_MODE.equals(deployMode)) {
             args.add(Constants.FLINK_RUN_MODE);  //-m
 
@@ -64,7 +65,7 @@ public class FlinkArgsUtils {
                 args.add(appName);
             }
 
-            // judgy flink version,from flink1.10,the parameter -yn removed
+            // judge flink version,from flink1.10,the parameter -yn removed
             String flinkVersion = param.getFlinkVersion();
             if (FLINK_VERSION_BEFORE_1_10.equals(flinkVersion)) {
                 int taskManager = param.getTaskManager();
@@ -85,8 +86,21 @@ public class FlinkArgsUtils {
                 args.add(taskManagerMemory);
             }
 
+            if (StringUtils.isEmpty(others) || !others.contains(Constants.FLINK_QUEUE)) {
+                String queue = param.getQueue();
+                if (StringUtils.isNotEmpty(queue)) { // -yqu
+                    args.add(Constants.FLINK_QUEUE);
+                    args.add(queue);
+                }
+            }
+
             args.add(Constants.FLINK_DETACH); //-d
 
+        }
+
+        // -p -s -yqu -yat -sae -yD -D
+        if (StringUtils.isNotEmpty(others)) {
+            args.add(others);
         }
 
         ProgramType programType = param.getProgramType();
@@ -104,21 +118,6 @@ public class FlinkArgsUtils {
         String mainArgs = param.getMainArgs();
         if (StringUtils.isNotEmpty(mainArgs)) {
             args.add(mainArgs);
-        }
-
-        // --files --conf --libjar ...
-        String others = param.getOthers();
-        String queue = param.getQueue();
-        if (StringUtils.isNotEmpty(others)) {
-
-            if (!others.contains(Constants.FLINK_QUEUE) && StringUtils.isNotEmpty(queue) && !deployMode.equals(LOCAL_DEPLOY_MODE)) {
-                args.add(Constants.FLINK_QUEUE);
-                args.add(param.getQueue());
-            }
-            args.add(others);
-        } else if (StringUtils.isNotEmpty(queue) && !deployMode.equals(LOCAL_DEPLOY_MODE)) {
-            args.add(Constants.FLINK_QUEUE);
-            args.add(param.getQueue());
         }
 
         return args;

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/flink/FlinkTask.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/worker/task/flink/FlinkTask.java
@@ -42,6 +42,7 @@ public class FlinkTask extends AbstractYarnTask {
 
   /**
    *  flink command
+   *  usage: flink run [OPTIONS] <jar-file> <arguments>
    */
   private static final String FLINK_COMMAND = "flink";
   private static final String FLINK_RUN = "run";
@@ -102,6 +103,7 @@ public class FlinkTask extends AbstractYarnTask {
    */
   @Override
   protected String buildCommand() {
+    // flink run [OPTIONS] <jar-file> <arguments>
     List<String> args = new ArrayList<>();
 
     args.add(FLINK_COMMAND);

--- a/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/utils/FlinkArgsUtilsTest.java
+++ b/dolphinscheduler-server/src/test/java/org/apache/dolphinscheduler/server/utils/FlinkArgsUtilsTest.java
@@ -46,9 +46,9 @@ public class FlinkArgsUtilsTest {
     public ProgramType programType = ProgramType.JAVA;
     public String mainClass = "com.test";
     public ResourceInfo mainJar = null;
-    public String mainArgs = "testArgs";
+    public String mainArgs = "testArgs --input file:///home";
     public String queue = "queue1";
-    public String others = "--input file:///home";
+    public String others = "-p 4";
     public String flinkVersion = "<1.10";
 
 
@@ -109,20 +109,20 @@ public class FlinkArgsUtilsTest {
         assertEquals("-ytm", result.get(10));
         assertEquals(result.get(11),taskManagerMemory);
 
-        assertEquals("-d", result.get(12));
+        assertEquals("-yqu", result.get(12));
+        assertEquals(result.get(13),queue);
 
-        assertEquals("-c", result.get(13));
-        assertEquals(result.get(14),mainClass);
+        assertEquals("-d", result.get(14));
 
-        assertEquals(result.get(15),mainJar.getRes());
-        assertEquals(result.get(16),mainArgs);
+        assertEquals(result.get(15),others);
 
-        assertEquals("--qu", result.get(17));
-        assertEquals(result.get(18),queue);
+        assertEquals("-c", result.get(16));
+        assertEquals(result.get(17),mainClass);
 
-        assertEquals(result.get(19),others);
+        assertEquals(result.get(18),mainJar.getRes());
+        assertEquals(result.get(19),mainArgs);
 
-        //Others param without --qu
+        //Others param without -yqu
         FlinkParameters param1 = new FlinkParameters();
         param1.setQueue(queue);
         param1.setDeployMode(mode);

--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/flink.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/formModel/tasks/flink.vue
@@ -62,7 +62,7 @@
         </x-radio-group>
       </div>
     </m-list-box>
-    <m-list-box>
+    <m-list-box v-if="deployMode === 'cluster'">
       <div slot="text">{{$t('Flink Version')}}</div>
       <div slot="content">
         <x-select
@@ -78,7 +78,7 @@
         </x-select>
       </div>
     </m-list-box>
-    <div class="list-box-4p">
+    <div class="list-box-4p" v-if="deployMode === 'cluster'">
       <div class="clearfix list">
         <span class="sp1" style="word-break:break-all">{{$t('jobManagerMemory')}}</span>
         <span class="sp2">

--- a/dolphinscheduler-ui/src/js/module/i18n/locale/zh_CN.js
+++ b/dolphinscheduler-ui/src/js/module/i18n/locale/zh_CN.js
@@ -535,7 +535,7 @@ export default {
   'Execute time': '执行时间',
   'Complement range': '补数范围',
   slot: 'slot数量',
-  taskManager: 'taskManage数量',
+  taskManager: 'taskManager数量',
   jobManagerMemory: 'jobManager内存数',
   taskManagerMemory: 'taskManager内存数',
   'Http Url': '请求地址',

--- a/pom.xml
+++ b/pom.xml
@@ -841,7 +841,7 @@
                         <include>**/server/utils/DataxUtilsTest.java</include>
                         <include>**/server/utils/ExecutionContextTestUtils.java</include>
                         <include>**/server/utils/HostTest.java</include>
-                        <!--<include>**/server/utils/FlinkArgsUtilsTest.java</include>-->
+                        <include>**/server/utils/FlinkArgsUtilsTest.java</include>
                         <include>**/server/utils/LogUtilsTest.java</include>
                         <include>**/server/utils/ParamUtilsTest.java</include>
                         <include>**/server/utils/ProcessUtilsTest.java</include>


### PR DESCRIPTION
## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

## What is the purpose of the pull request

*Fix flink args build problem* #3457 

this closes #3987 #3457 

The official flink run command is `flink run [OPTIONS] <jar-file> <arguments>` (ref: [flink-1.9-cli](https://ci.apache.org/projects/flink/flink-docs-release-1.9/ops/cli.html) and  [flink-1.11-cli](https://ci.apache.org/projects/flink/flink-docs-release-1.11/ops/cli.html)), but there are some errors in the code:
 - the `other args` is after the `main args`, so that it will be part of the `<arguments>`
 - the flink queue option is also after the `main args`, so that the option doesn't work
 - the flink queue option is `-yqu`, not `--qu`, and it's only for yarn. see [flink-1.9-cli](https://ci.apache.org/projects/flink/flink-docs-release-1.9/ops/cli.html) and  [flink-1.11-cli](https://ci.apache.org/projects/flink/flink-docs-release-1.11/ops/cli.html)
 - the comment `--files --conf --libjar ...` is for spark, not for flink

## Brief change log

*Flink args:*
 - *[Fix][Flink] fix flink args build problem*
   - Adjust the order of the `other args` and optimize the logic
   - Rename the flink queue option `--qu` to `-yqu`
 - *[Fix][Flink] fix FlinkArgsUtilsTest*
 - *[Improvement][UI] hide version and cluster input when deployMode is local*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(and)

This change added tests and can be verified as follows:

Assume that:
 - main args: `--input file:///home/user/hamlet.txt --output file:///home/user/wordcount_out`
- other args: `-p 4`

**Before fix, the generated flink commands are as follow**:
 - **local**: `flink run -c org.apache.flink.examples.java.wordcount.WordCount WordCount.jar --input file:///home/user/hamlet.txt --output file:///home/user/wordcount_out -p 4`
 - **cluster**: `flink run -m yarn-cluster -ys 1 -yn 2 -yjm 1G -ytm 2G -d -c org.apache.flink.examples.java.wordcount.WordCount WordCount.jar --input file:///home/user/hamlet.txt --output file:///home/user/wordcount_out --qu test -p 4`

**After fix, the generated flink commands are as follow**:
 - **local**: `flink run -p 4 -c org.apache.flink.examples.java.wordcount.WordCount WordCount.jar --input file:///home/user/hamlet.txt --output file:///home/user/wordcount_out`
 - **cluster**: `flink run -m yarn-cluster -ys 1 -yn 2 -yjm 1G -ytm 2G -yqu test -d -p 4 -c org.apache.flink.examples.java.wordcount.WordCount WordCount.jar --input file:///home/user/hamlet.txt --output file:///home/user/wordcount_out`

For the commit *[Improvement][UI] hide version and cluster input when deployMode is local*:
![image](http://g.recordit.co/gFwAZi7U09.gif)
