### PR TITLE
[FIX-#4184][server-api] load TaskInstance slow 

### DIFF
--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/TaskInstanceMapper.xml
@@ -120,8 +120,8 @@
         ,
         process.name as process_instance_name
         from t_ds_task_instance instance
-        join t_ds_process_definition define on instance.process_definition_id = define.id
-        join t_ds_process_instance process on process.id=instance.process_instance_id
+        left join t_ds_process_definition define on instance.process_definition_id = define.id
+        left join t_ds_process_instance process on process.id=instance.process_instance_id
         where define.project_id = #{projectId}
         <if test="startTime != null">
             and instance.start_time > #{startTime} and instance.start_time <![CDATA[ <=]]> #{endTime}


### PR DESCRIPTION
[FIX-#4184][server-api] load TaskInstanceslow 
page of [TaskInstance] load data by interface "/dolphinscheduler/projects/stressTes/task-instance/list-paging" slow when the size of result more than 230000.
change "join" to " join left " in sql 