### PR TITLE
[FIX-PR-4097][server-master]task ack miss

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/processor/queue/TaskResponseService.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/processor/queue/TaskResponseService.java
@@ -138,8 +138,9 @@ public class TaskResponseService {
             case ACK:
                 try {
                     TaskInstance taskInstance = processService.findTaskInstanceById(taskResponseEvent.getTaskInstanceId());
-                    if (taskInstance != null && !taskInstance.getState().typeIsFinished()) {
-                        processService.changeTaskState(taskInstance, taskResponseEvent.getState(),
+                    if (taskInstance != null) {
+                        ExecutionStatus status = taskInstance.getState().typeIsFinished() ? taskInstance.getState() : taskResponseEvent.getState();
+                        processService.changeTaskState(taskInstance, status,
                             taskResponseEvent.getStartTime(),
                             taskResponseEvent.getWorkerAddress(),
                             taskResponseEvent.getExecutePath(),


### PR DESCRIPTION
When the message of successful execution arrives earlier than
the message of ack,
the message of ack will be discarded,
resulting in some information missing

see #4097 