### PR TITLE
[Fix-4191][common]Cannot construct instance... (no Creators, like default construct, exist)

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/JSONUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/JSONUtils.java
@@ -19,6 +19,7 @@ package org.apache.dolphinscheduler.common.utils;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import static com.fasterxml.jackson.core.JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES;
 import static com.fasterxml.jackson.databind.DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT;
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import static com.fasterxml.jackson.databind.DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL;
@@ -34,10 +35,13 @@ import java.util.TimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.JsonSerializer;
@@ -65,6 +69,8 @@ public class JSONUtils {
             .configure(ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT, true)
             .configure(READ_UNKNOWN_ENUM_VALUES_AS_NULL, true)
             .configure(REQUIRE_SETTERS_FOR_GETTERS, true)
+            .configure(ALLOW_UNQUOTED_FIELD_NAMES,true)
+            .enable(ALLOW_UNQUOTED_FIELD_NAMES)
             .setTimeZone(TimeZone.getDefault());
 
     private JSONUtils() {

--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/JSONUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/JSONUtils.java
@@ -70,7 +70,6 @@ public class JSONUtils {
             .configure(READ_UNKNOWN_ENUM_VALUES_AS_NULL, true)
             .configure(REQUIRE_SETTERS_FOR_GETTERS, true)
             .configure(ALLOW_UNQUOTED_FIELD_NAMES,true)
-            .enable(ALLOW_UNQUOTED_FIELD_NAMES)
             .setTimeZone(TimeZone.getDefault());
 
     private JSONUtils() {

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/JSONUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/JSONUtilsTest.java
@@ -22,6 +22,7 @@ import org.apache.dolphinscheduler.common.enums.Direct;
 import org.apache.dolphinscheduler.common.model.TaskNode;
 import org.apache.dolphinscheduler.common.process.Property;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -246,8 +247,56 @@ public class JSONUtilsTest {
                 + "\"timeout\":\"{}\",\"type\":\"SHELL\",\"workerGroup\":\"default\"}";
 
         TaskNode taskNode = JSONUtils.parseObject(a, TaskNode.class);
-
         Assert.assertTrue(true);
     }
 
+    @Test
+    public void parseObjectToClassTest(){
+        String a = "{\"taskInstanceId\":15,\"status\":7}";
+
+        TaskCommand c = JSONUtils.parseObject(a, TaskCommand.class);
+        Assert.assertEquals(7, c.getStatus());
+    }
+
+    private static class TaskCommand implements Serializable {
+
+        private int taskInstanceId;
+        private int status;
+
+        public TaskCommand(){}
+        public TaskCommand(int taskInstanceId,int status) {
+            this.taskInstanceId = taskInstanceId;
+            this.status = status;
+        }
+
+        public TaskCommand(String status,String taskInstanceId) {
+            this.taskInstanceId = Integer.valueOf(taskInstanceId);
+            this.status = Integer.valueOf(status);
+        }
+
+        public int getTaskInstanceId() {
+            return taskInstanceId;
+        }
+
+        public void setTaskInstanceId(int taskInstanceId) {
+            this.taskInstanceId = taskInstanceId;
+        }
+
+        public int getStatus() {
+            return status;
+        }
+
+        public void setStatus(int status) {
+            this.status = status;
+        }
+
+
+        @Override
+        public String toString() {
+            return "DBTaskAckCommand{" +
+                    "taskInstanceId=" + taskInstanceId +
+                    ", status=" + status +
+                    '}';
+        }
+    }
 }

--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/DBTaskAckCommand.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/DBTaskAckCommand.java
@@ -29,6 +29,12 @@ public class DBTaskAckCommand implements Serializable {
     private int taskInstanceId;
     private int status;
 
+    /**
+     * don't delete this construct method
+     */
+    public DBTaskAckCommand(){
+
+    }
     public DBTaskAckCommand(int status, int taskInstanceId) {
         this.status = status;
         this.taskInstanceId = taskInstanceId;

--- a/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/DBTaskResponseCommand.java
+++ b/dolphinscheduler-remote/src/main/java/org/apache/dolphinscheduler/remote/command/DBTaskResponseCommand.java
@@ -28,6 +28,12 @@ public class DBTaskResponseCommand implements Serializable {
     private int taskInstanceId;
     private int status;
 
+    /**
+     * don't delete this construct method
+     */
+    public DBTaskResponseCommand(){
+
+    }
     public DBTaskResponseCommand(int status,int taskInstanceId) {
         this.status = status;
         this.taskInstanceId = taskInstanceId;


### PR DESCRIPTION
fix #4191 exception

[ERROR] 2020-12-09 17:38:14.996 org.apache.dolphinscheduler.common.utils.JSONUtils:[126] - parse object exception!
com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of org.apache.dolphinscheduler.remote.command.DBTaskResponseCommand (no Creators, like default construct, exist): cannot deserialize from Object value (no delegate- or property-based Creator)
at [Source: (String)"{"taskInstanceId":15,"status":7}"; line: 1, column: 2]