### PR TITLE
[FIX-4190][DAO] When the amount of json data is large, the process list page display slowly.

### DIFF
--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessInstanceMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessInstanceMapper.xml
@@ -88,17 +88,9 @@
     </select>
 
     <select id="queryProcessInstanceListPaging" resultType="org.apache.dolphinscheduler.dao.entity.ProcessInstance">
-        select
-        instance.id, instance.name, instance.process_definition_id, instance.state, instance.recovery,
-        instance.start_time, instance.end_time, instance.run_times, instance.host,
-        instance.command_type, instance.command_param, instance.task_depend_type, instance.max_try_times,
-        instance.failure_strategy, instance.warning_type,
-        instance.warning_group_id, instance.schedule_time, instance.command_start_time, instance.global_params,
-        instance.process_instance_json, instance.flag,
-        instance.update_time, instance.is_sub_process, instance.executor_id, instance.locations, instance.connects,
-        instance.history_cmd, instance.dependence_schedule_times,
-        instance.process_instance_priority, instance.worker_group, instance.timeout, instance.tenant_id,
-        instance.var_pool
+        select instance.id, instance.process_definition_id, instance.command_type, instance.executor_id,
+        instance.name, instance.state, instance.schedule_time, instance.start_time, instance.end_time,
+        instance.run_times, instance.recovery, instance.host
         from t_ds_process_instance instance
         join t_ds_process_definition define ON instance.process_definition_id = define.id
         where 1=1

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessInstanceMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessInstanceMapper.xml
@@ -93,7 +93,6 @@
         instance.run_times, instance.recovery, instance.host
         from t_ds_process_instance instance
         join t_ds_process_definition define ON instance.process_definition_id = define.id
-        where 1=1
         and instance.is_sub_process=0
         and define.project_id = #{projectId}
         <if test="processDefinitionId != 0">

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessInstanceMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessInstanceMapper.xml
@@ -93,7 +93,7 @@
         instance.run_times, instance.recovery, instance.host
         from t_ds_process_instance instance
         join t_ds_process_definition define ON instance.process_definition_id = define.id
-        and instance.is_sub_process=0
+        where instance.is_sub_process=0
         and define.project_id = #{projectId}
         <if test="processDefinitionId != 0">
             and instance.process_definition_id = #{processDefinitionId}


### PR DESCRIPTION
fix #4190 : When the amount of json data is large, the process list page display slowly.