### PR TITLE
[Feature-#3252][build]plugins need put in plugins dir when install

### DIFF
--- a/dolphinscheduler-alert-plugin/dolphinscheduler-alert-dingtalk/pom.xml
+++ b/dolphinscheduler-alert-plugin/dolphinscheduler-alert-dingtalk/pom.xml
@@ -75,4 +75,8 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <finalName>dolphinscheduler-alert-dingtalk-${project.version}</finalName>
+    </build>
+
 </project>

--- a/dolphinscheduler-alert-plugin/dolphinscheduler-alert-email/pom.xml
+++ b/dolphinscheduler-alert-plugin/dolphinscheduler-alert-email/pom.xml
@@ -121,4 +121,8 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <finalName>dolphinscheduler-alert-email-${project.version}</finalName>
+    </build>
+
 </project>

--- a/dolphinscheduler-alert-plugin/dolphinscheduler-alert-http/pom.xml
+++ b/dolphinscheduler-alert-plugin/dolphinscheduler-alert-http/pom.xml
@@ -69,4 +69,8 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <finalName>dolphinscheduler-alert-http-${project.version}</finalName>
+    </build>
+
 </project>

--- a/dolphinscheduler-alert-plugin/dolphinscheduler-alert-script/pom.xml
+++ b/dolphinscheduler-alert-plugin/dolphinscheduler-alert-script/pom.xml
@@ -72,4 +72,8 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <finalName>dolphinscheduler-alert-script-${project.version}</finalName>
+    </build>
+
 </project>

--- a/dolphinscheduler-alert-plugin/dolphinscheduler-alert-wechat/pom.xml
+++ b/dolphinscheduler-alert-plugin/dolphinscheduler-alert-wechat/pom.xml
@@ -72,4 +72,7 @@
 
      </dependencies>
 
+    <build>
+        <finalName>dolphinscheduler-alert-wechat-${project.version}</finalName>
+    </build>
 </project>

--- a/dolphinscheduler-dist/pom.xml
+++ b/dolphinscheduler-dist/pom.xml
@@ -25,7 +25,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dolphinscheduler-dist</artifactId>
-    <packaging>pom</packaging>
+    <packaging>provisio</packaging>
     <name>${project.artifactId}</name>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/dolphinscheduler-dist/src/main/provisio/dolphinscheduler.xml
+++ b/dolphinscheduler-dist/src/main/provisio/dolphinscheduler.xml
@@ -1,0 +1,67 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<runtime>
+    <!-- Target -->
+    <archive name="${project.artifactId}-${project.version}.tar.gz" hardLinkIncludes="**/*.jar"/>
+    <!-- Notices -->
+    <fileSet to="/">
+        <directory path="${basedir}/../">
+            <include>DISCLAIMER</include>
+            <include>install.sh</include>
+            <include>LICENSE</include>
+            <include>NOTICE</include>
+        </directory>
+
+    </fileSet>
+
+    <!-- Server -->
+    <artifactSet to="bin">
+        <artifact id="io.airlift:launcher:tar.gz:bin:${dep.packaging.version}">
+            <unpack/>
+        </artifact>
+        <artifact id="io.airlift:launcher:tar.gz:properties:${dep.packaging.version}">
+            <unpack filter="true"/>
+        </artifact>
+    </artifactSet>
+
+    <!-- Plugins -->
+    <artifactSet to="lib/plugin/alert/email">
+        <artifact id="${project.groupId}:dolphinscheduler-alert-email:zip:${project.version}">
+            <unpack/>
+        </artifact>
+    </artifactSet>
+    <artifactSet to="lib/plugin/alert/script">
+        <artifact id="${project.groupId}:dolphinscheduler-alert-script:zip:${project.version}">
+            <unpack/>
+        </artifact>
+    </artifactSet>
+    <artifactSet to="lib/plugin/alert/wechat">
+        <artifact id="${project.groupId}:dolphinscheduler-alert-wechat:zip:${project.version}">
+            <unpack/>
+        </artifact>
+    </artifactSet>
+    <artifactSet to="lib/plugin/alert/dingtalk">
+        <artifact id="${project.groupId}:dolphinscheduler-alert-dingtalk:zip:${project.version}">
+            <unpack/>
+        </artifact>
+    </artifactSet>
+    <artifactSet to="lib/plugin/alert/http">
+        <artifact id="${project.groupId}:dolphinscheduler-alert-http:zip:${project.version}">
+            <unpack/>
+        </artifact>
+    </artifactSet>
+</runtime>

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,8 @@
         <swagger.version>1.9.3</swagger.version>
         <springfox.version>2.9.2</springfox.version>
         <guava-retry.version>2.0.0</guava-retry.version>
+        <dep.airlift.version>0.184</dep.airlift.version>
+        <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Update maven build, put the alert plugins in the ${install_dir}/lib/plugin/alert/${plugin_module_name} directory
(assembly build and rpm build).
Note: When adding a new plug-in, it must be reflected in provisio/dolphinscheduler.xml.

this closes  #3252
