### PR TITLE
[fix-4264][UI]The deletion function of version information in DAG diagram cannot work normally

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/dag.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/dag.vue
@@ -754,6 +754,29 @@
       },
 
       /**
+       * delete one version of process definition
+       *
+       * @param version the version need to delete
+       * @param processDefinitionId the process definition id user want to delete
+       * @param fromThis fromThis
+       */
+      mVersionDeleteProcessDefinitionVersion ({ version, processDefinitionId, fromThis }) {
+        this.deleteProcessDefinitionVersion({
+          version: version,
+          processDefinitionId: processDefinitionId
+        }).then(res => {
+          this.$message.success(res.msg || '')
+          this.mVersionGetProcessDefinitionVersionsPage({
+            pageNo: 1,
+            pageSize: 10,
+            processDefinitionId: processDefinitionId,
+            fromThis: fromThis
+          })
+        }).catch(e => {
+          this.$message.error(e.msg || '')
+        })
+      },
+      /**
        * query the process definition pagination version
        */
       _version (item) {


### PR DESCRIPTION
## What is the purpose of the pull request
this closes #4264 

fix  the version information deletion function  of DAG diagram interface of workflow definition is not available

## Brief change log

Add mVersionDeleteProcessDefinitionVersion method in the dag.vue file

## Verify this pull request

This change added tests and can be verified as follows:
  - *Manually verified the change by testing locally.*
