### PR TITLE
[Fix-4271][server] Fix IOException or NoSuchFileException in logger server

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/log/LoggerRequestProcessor.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/log/LoggerRequestProcessor.java
@@ -169,10 +169,15 @@ public class LoggerRequestProcessor implements NettyRequestProcessor {
     private List<String> readPartFileContent(String filePath,
                                             int skipLine,
                                             int limit) {
-        try (Stream<String> stream = Files.lines(Paths.get(filePath))) {
-            return stream.skip(skipLine).limit(limit).collect(Collectors.toList());
-        } catch (IOException e) {
-            logger.error("read file error",e);
+        File file = new File(filePath);
+        if (file.exists() && file.isFile()) {
+            try (Stream<String> stream = Files.lines(Paths.get(filePath))) {
+                return stream.skip(skipLine).limit(limit).collect(Collectors.toList());
+            } catch (IOException e) {
+                logger.error("read file error",e);
+            }
+        } else {
+            logger.info("file path: {} not exists", filePath);
         }
         return Collections.emptyList();
     }


### PR DESCRIPTION
## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

## What is the purpose of the pull request

this closes #4271 

## Brief change log

- *Check whether `filePath` exists in logger server*

## Verify this pull request

*(Please pick either of the following options)*

This change added tests and can be verified as follows:

*(example:)*

  - *Manually verified the change by testing locally.*
