### PR TITLE
[fix-4291][UI] user management authorization operation exceptions do not prompt exception information 

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/pages/security/pages/users/_source/list.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/security/pages/users/_source/list.vue
@@ -179,6 +179,8 @@
           this.transferData.targetListPrs = targetListPrs
           this.transferData.type.name = `${i18n.$t('Project')}`
           this.authProjectDialog = true
+        }).catch(e => {
+          this.$message.error(e.msg || '')
         })
       },
       onUpdateAuthProject (projectIds) {
@@ -256,6 +258,8 @@
           this.resourceData.udfTargetList = udfTargetList
           this.resourceData.type.name = `${i18n.$t('Resources')}`
           this.resourceDialog = true
+        }).catch(e => {
+          this.$message.error(e.msg || '')
         })
       },
 
@@ -294,6 +298,8 @@
           this.transferData.targetListPrs = targetListPrs
           this.transferData.type.name = `${i18n.$t('Datasource')}`
           this.authDataSourceDialog = true
+        }).catch(e => {
+          this.$message.error(e.msg || '')
         })
       },
       onUpdateAuthDataSource (datasourceIds) {
@@ -330,6 +336,8 @@
           this.transferData.targetListPrs = targetListPrs
           this.transferData.type.name = `${i18n.$t('UDF Function')}`
           this.authUdfFuncDialog = true
+        }).catch(e => {
+          this.$message.error(e.msg || '')
         })
       },
       onUpdateAuthUdfFunc (udfIds) {


### PR DESCRIPTION
## What is the purpose of the pull request
this closes #4291 
fix user management authorization operation exceptions do not prompt exception information 

## Brief change log

add  .catch(e => {
          this.$message.error(e.msg || '')
    })

## Verify this pull request

This change added tests and can be verified as follows:
  - *Manually verified the change by testing locally.*
