### PR TITLE
[fix-4301][dao] The token management list does not display the user name

### DIFF
--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/AccessTokenMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/AccessTokenMapper.xml
@@ -19,7 +19,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
 <mapper namespace="org.apache.dolphinscheduler.dao.mapper.AccessTokenMapper">
     <select id="selectAccessTokenPage" resultType="org.apache.dolphinscheduler.dao.entity.AccessToken">
-        select t.id, t.user_id, t.token, t.expire_time, t.create_time, t.update_time
+        select t.id, t.user_id, t.token, t.expire_time, t.create_time, t.update_time, u.user_name
         from t_ds_access_token t
         left join t_ds_user u on t.user_id = u.id
         where 1 = 1


### PR DESCRIPTION
## What is the purpose of the pull request
this closes #4301 
fix the token management list does not display the user name

## Brief change log
add user_name in select sql 

## Verify this pull request

This change added tests and can be verified as follows:
  - *Manually verified the change by testing locally.*
