### PR TITLE
 Let the user decide the maximum number of failures, so that the user can control the maximum amount of logs

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterSchedulerService.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterSchedulerService.java
@@ -93,7 +93,7 @@ public class MasterSchedulerService extends Thread {
     private int maxDbConnRetrytimes;
 
     /**
-     * Database connection times
+     * Number of database connection failures
      */
     private int connRetrytimes=0;
 
@@ -169,7 +169,7 @@ public class MasterSchedulerService extends Thread {
                     logger.error("Database connection failed more than the maximum number of times : maxdbconnretrytimes: {}", maxDbConnRetrytimes);
                     Stopper.stop();
                 }
-                e.printStackTrace();
+                logger.error("Database connection failed ", e);
             }
             if (command != null) {
                 logger.info("find one command: id: {}, type: {}", command.getId(),command.getCommandType());

--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterSchedulerService.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterSchedulerService.java
@@ -39,6 +39,7 @@ import org.apache.dolphinscheduler.service.process.ProcessService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /**
@@ -84,6 +85,17 @@ public class MasterSchedulerService extends Thread {
      * master exec service
      */
     private ThreadPoolExecutor masterExecService;
+
+    /**
+     * Maximum number of retries for database connection failure
+     */
+    @Value("${maxdbconnretrytimes:360}")
+    private int maxDbConnRetrytimes;
+
+    /**
+     * Database connection times
+     */
+    private int connRetrytimes=0;
 
 
     /**
@@ -146,7 +158,19 @@ public class MasterSchedulerService extends Thread {
 
             int activeCount = masterExecService.getActiveCount();
             // make sure to scan and delete command  table in one transaction
-            Command command = processService.findOneCommand();
+            Command command = null;
+            try {
+                command = processService.findOneCommand();
+                connRetrytimes=0;
+            } catch (Exception e) {
+                connRetrytimes++;
+                logger.info("Database connection retries : connRetrytimes: {}", connRetrytimes);
+                if (connRetrytimes>=maxDbConnRetrytimes){
+                    logger.error("Database connection failed more than the maximum number of times : maxdbconnretrytimes: {}", maxDbConnRetrytimes);
+                    Stopper.stop();
+                }
+                e.printStackTrace();
+            }
             if (command != null) {
                 logger.info("find one command: id: {}, type: {}", command.getId(),command.getCommandType());
 

--- a/dolphinscheduler-server/src/main/resources/master.properties
+++ b/dolphinscheduler-server/src/main/resources/master.properties
@@ -43,3 +43,5 @@
 
 # master listen port
 #master.listen.port=5678
+
+#maxdbconnretrytimes=360


### PR DESCRIPTION
## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

## What is the purpose of the pull request
If the database is dead and cannot be connected all the time, the master will easily fill the log. Let the user decide the maximum number of failures, so that the user can control the maximum amount of logs.
*(For example: This pull request adds checkstyle plugin.)*

## Brief change log

*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.*
