### PR TITLE
[Fix-4335][UI] Fix IE 9-11 not supported

### DIFF
--- a/dolphinscheduler-ui/.babelrc
+++ b/dolphinscheduler-ui/.babelrc
@@ -5,7 +5,15 @@
         "debug": false,
         "useBuiltIns": true,
         "targets": {
-          "browsers": [ "ie > 8", "last 2 version", "safari >= 9" ]
+          "browsers": [
+            "> 1%",
+            "last 2 versions",
+            "ie >= 9",
+            "edge >= 12",
+            "firefox >= 28",
+            "chrome >= 29",
+            "opera >= 17"
+          ]
         },
         "production": {
           "plugins": ["transform-remove-console"]

--- a/dolphinscheduler-ui/build/config.js
+++ b/dolphinscheduler-ui/build/config.js
@@ -47,7 +47,7 @@ const jsEntry = (() => {
     parts.shift()
     let modules = parts.join('/')
     let entry = moduleName(modules)
-    obj[entry] = val
+    obj[entry] = ['babel-polyfill', val]
   })
   return obj
 })()

--- a/dolphinscheduler-ui/package.json
+++ b/dolphinscheduler-ui/package.json
@@ -48,6 +48,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-plugin-transform-vue-jsx": "^3.5.0",
+    "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "copy-webpack-plugin": "^4.5.2",
     "cross-env": "^5.2.0",
@@ -86,5 +87,14 @@
     "webpack-cli": "^3.3.10",
     "webpack-dev-server": "^3.9.0",
     "webpack-merge": "^4.2.2"
-  }
+  },
+  "browserslist": [
+    "> 1%",
+    "last 2 versions",
+    "ie >= 9",
+    "edge >= 12",
+    "firefox >= 28",
+    "chrome >= 29",
+    "opera >= 17"
+  ]
 }

--- a/dolphinscheduler-ui/src/js/conf/home/index.js
+++ b/dolphinscheduler-ui/src/js/conf/home/index.js
@@ -17,6 +17,7 @@
 
 // The Vue build version to load with the `import` command
 // (runtime-only or standalone) has been set in webpack.base.conf with an alias.
+import 'babel-polyfill'
 import Vue from 'vue'
 import ElementUI from 'element-ui'
 import locale from 'element-ui/lib/locale/lang/en'

--- a/dolphinscheduler-ui/src/js/conf/login/index.js
+++ b/dolphinscheduler-ui/src/js/conf/login/index.js
@@ -18,6 +18,7 @@
 // The Vue build version to load with the `import` command
 // (runtime-only or standalone) has been set in webpack.base.conf with an alias.
 // import $ from 'jquery'
+import 'babel-polyfill'
 import Vue from 'vue'
 import ElementUI from 'element-ui'
 import locale from 'element-ui/lib/locale/lang/en'


### PR DESCRIPTION
## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

## What is the purpose of the pull request

Fix IE 9-11 not supported
This closes #4335

## Brief change log

  - *Add babel-polyfill*

## Verify this pull request

This change added tests and can be verified as follows:

*(example:)*

  - *Manually verified the change by testing locally.*

**After fix**:
![image](https://user-images.githubusercontent.com/4902714/103277428-e9a20980-4a03-11eb-9956-2cde5593d5d8.png)
