### PR TITLE
Let the user decide the maximum number of failures, so that the user can control the maximum amount of logs

### DIFF
--- a/dolphinscheduler-server/src/main/resources/master.properties
+++ b/dolphinscheduler-server/src/main/resources/master.properties
@@ -43,3 +43,7 @@
 
 # master listen port
 #master.listen.port=5678
+
+
+#Maximum number of failed database retries
+#maxdbconnretrytimes=360


### PR DESCRIPTION
## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*
If the database is dead and cannot be connected all the time, it is easy for the master to fill up the log, and let the user decide the maximum number of failures by himself. In this way, the master can control the maximum number of logs.
## What is the purpose of the pull request

*(For example: This pull request adds checkstyle plugin.)*

## Brief change log

*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.*
