### PR TITLE
Master schedule service improve

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterSchedulerService.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/master/runner/MasterSchedulerService.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.dolphinscheduler.server.master.runner;
 
 import java.util.concurrent.ThreadPoolExecutor;
@@ -21,9 +22,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.annotation.PostConstruct;
 
-import org.apache.curator.framework.imps.CuratorFrameworkState;
-import org.apache.curator.framework.recipes.locks.InterProcessMutex;
-import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.thread.Stopper;
 import org.apache.dolphinscheduler.common.thread.ThreadUtils;
 import org.apache.dolphinscheduler.common.utils.NetUtils;
@@ -36,6 +34,11 @@ import org.apache.dolphinscheduler.server.master.config.MasterConfig;
 import org.apache.dolphinscheduler.server.utils.AlertManager;
 import org.apache.dolphinscheduler.server.zk.ZKMasterClient;
 import org.apache.dolphinscheduler.service.process.ProcessService;
+import org.apache.dolphinscheduler.common.Constants;
+
+import org.apache.curator.framework.recipes.locks.InterProcessMutex;
+import org.apache.curator.framework.imps.CuratorFrameworkState;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,7 +46,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /**
- *  master scheduler thread
+ * master scheduler thread
  */
 @Service
 public class MasterSchedulerService extends Thread {
@@ -77,7 +80,7 @@ public class MasterSchedulerService extends Thread {
     private AlertManager alertManager = new AlertManager();
 
     /**
-     *  netty remoting client
+     * netty remoting client
      */
     private NettyRemotingClient nettyRemotingClient;
 
@@ -95,21 +98,21 @@ public class MasterSchedulerService extends Thread {
     /**
      * Number of database connection failures
      */
-    private int connRetrytimes=0;
+    private int connRetrytimes = 0;
 
 
     /**
      * constructor of MasterSchedulerService
      */
     @PostConstruct
-    public void init(){
-        this.masterExecService = (ThreadPoolExecutor)ThreadUtils.newDaemonFixedThreadExecutor("Master-Exec-Thread", masterConfig.getMasterExecThreads());
+    public void init() {
+        this.masterExecService = (ThreadPoolExecutor) ThreadUtils.newDaemonFixedThreadExecutor("Master-Exec-Thread", masterConfig.getMasterExecThreads());
         NettyClientConfig clientConfig = new NettyClientConfig();
         this.nettyRemotingClient = new NettyRemotingClient(clientConfig);
     }
 
     @Override
-    public synchronized void start(){
+    public synchronized void start() {
         super.setName("MasterSchedulerService");
         super.start();
     }
@@ -122,7 +125,7 @@ public class MasterSchedulerService extends Thread {
         } catch (InterruptedException ignore) {
             Thread.currentThread().interrupt();
         }
-        if(!terminated){
+        if (!terminated) {
             logger.warn("masterExecService shutdown without terminated, increase await time");
         }
         nettyRemotingClient.close();
@@ -135,7 +138,7 @@ public class MasterSchedulerService extends Thread {
     @Override
     public void run() {
         logger.info("master scheduler started");
-        while (Stopper.isRunning()){
+        while (Stopper.isRunning()) {
             try {
                 boolean runCheckFlag = OSUtils.checkResource(masterConfig.getMasterMaxCpuloadAvg(), masterConfig.getMasterReservedMemory());
                 if (!runCheckFlag) {
@@ -155,37 +158,36 @@ public class MasterSchedulerService extends Thread {
         InterProcessMutex mutex = null;
         try {
             mutex = zkMasterClient.blockAcquireMutex();
-
             int activeCount = masterExecService.getActiveCount();
             // make sure to scan and delete command  table in one transaction
             Command command = null;
             try {
                 command = processService.findOneCommand();
-                connRetrytimes=0;
+                connRetrytimes = 0;
             } catch (Exception e) {
                 connRetrytimes++;
                 logger.info("Database connection retries : connRetrytimes: {}", connRetrytimes);
-                if (connRetrytimes>=maxDbConnRetrytimes){
+                if (connRetrytimes >= maxDbConnRetrytimes) {
                     logger.error("Database connection failed more than the maximum number of times : maxdbconnretrytimes: {}", maxDbConnRetrytimes);
                     Stopper.stop();
                 }
                 logger.error("Database connection failed ", e);
             }
             if (command != null) {
-                logger.info("find one command: id: {}, type: {}", command.getId(),command.getCommandType());
+                logger.info("find one command: id: {}, type: {}", command.getId(), command.getCommandType());
                 try {
                     ProcessInstance processInstance = processService.handleCommand(logger,
-                            getLocalAddress(),
-                            this.masterConfig.getMasterExecThreads() - activeCount, command);
+                        getLocalAddress(),
+                        this.masterConfig.getMasterExecThreads() - activeCount, command);
                     if (processInstance != null) {
                         logger.info("start master exec thread , split DAG ...");
                         masterExecService.execute(
-                                new MasterExecThread(
-                                        processInstance
-                                        , processService
-                                        , nettyRemotingClient
-                                        , alertManager
-                                        , masterConfig));
+                            new MasterExecThread(
+                                processInstance
+                                , processService
+                                , nettyRemotingClient
+                                , alertManager
+                                , masterConfig));
                     }
                 } catch (Exception e) {
                     logger.error("scan command error ", e);
@@ -200,7 +202,7 @@ public class MasterSchedulerService extends Thread {
         }
     }
 
-    private String getLocalAddress(){
+    private String getLocalAddress() {
         return NetUtils.getHost() + ":" + masterConfig.getListenPort();
     }
 }

--- a/dolphinscheduler-server/src/main/resources/master.properties
+++ b/dolphinscheduler-server/src/main/resources/master.properties
@@ -43,3 +43,7 @@
 
 # master listen port
 #master.listen.port=5678
+
+
+#Maximum number of failed database retries
+#maxdbconnretrytimes=360

--- a/dolphinscheduler-server/src/main/resources/master.properties
+++ b/dolphinscheduler-server/src/main/resources/master.properties
@@ -44,6 +44,5 @@
 # master listen port
 #master.listen.port=5678
 
-
-#Maximum number of failed database retries
+# Maximum number of failed database retries
 #maxdbconnretrytimes=360


### PR DESCRIPTION
If the database is dead and can't be connected all the time, the master is easy to fill the log and let the user decide the maximum number of failures. If the number of failures is reached, the master exits. In this way, the maximum number of logs is controlled. The default number of database reconnections is 360.
