### PR TITLE
[Fix][common] only two yarns can be selected(#4314)

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HadoopUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HadoopUtils.java
@@ -649,27 +649,25 @@ public class HadoopUtils implements Closeable {
 
             String yarnUrl = "http://%s:" + activeResourceManagerPort + "/ws/v1/cluster/info";
 
-            String state = null;
             try {
-                /**
-                 * send http get request to rm1
-                 */
-                state = getRMState(String.format(yarnUrl, rmIdArr[0]));
 
-                if (Constants.HADOOP_RM_STATE_ACTIVE.equals(state)) {
-                    return rmIdArr[0];
-                } else if (Constants.HADOOP_RM_STATE_STANDBY.equals(state)) {
-                    state = getRMState(String.format(yarnUrl, rmIdArr[1]));
+                /**
+                 * send http get request to rm
+                 */
+
+                for (String rmId : rmIdArr) {
+                    String state = getRMState(String.format(yarnUrl, rmId));
                     if (Constants.HADOOP_RM_STATE_ACTIVE.equals(state)) {
-                        return rmIdArr[1];
+                        return rmId;
                     }
-                } else {
-                    return null;
                 }
+
             } catch (Exception e) {
-                state = getRMState(String.format(yarnUrl, rmIdArr[1]));
-                if (Constants.HADOOP_RM_STATE_ACTIVE.equals(state)) {
-                    return rmIdArr[0];
+                for (int i = 1; i < rmIdArr.length; i++) {
+                    String  state = getRMState(String.format(yarnUrl, rmIdArr[i]));
+                    if (Constants.HADOOP_RM_STATE_ACTIVE.equals(state)) {
+                        return rmIdArr[i];
+                    }
                 }
             }
             return null;


### PR DESCRIPTION
## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

Fixed the problem of judging only 2 nodes in yarnhdips

this closes #4314 

## Brief change log

Modify getAcitveRMName in org\apache\dolphinscheduler\common\utils\HadoopUtils.java

## Verify this pull request

This change added tests and can be verified as follows:

  - *Manually verified the change by testing locally.*
