### PR TITLE
[Improvement-4326][ui] Add description field to data source list

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/pages/datasource/pages/list/_source/list.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/datasource/pages/list/_source/list.vue
@@ -32,6 +32,11 @@
             </div>
           </template>
         </el-table-column>
+        <el-table-column :label="$t('Description')" min-width="100">
+          <template slot-scope="scope">
+            <span>{{scope.row.note | filterNull}}</span>
+          </template>
+        </el-table-column>
         <el-table-column :label="$t('Create Time')" min-width="120">
           <template slot-scope="scope">
             <span>{{scope.row.createTime | formatDate}}</span>


### PR DESCRIPTION
## What is the purpose of the pull request

 Add description field to data source list. resolve the issue [#4326](https://github.com/apache/incubator-dolphinscheduler/issues/4326)
this close #4362 
## Brief change log

modify dolphinscheduler-ui/src/js/conf/home/pages/datasource/pages/list/_source/list.vue

## Verify this pull request

ui improvement. check datasource  page ui：

- *cd  dolphinscheduler-ui*
- *run "npm run start"*
- *go to "http://localhost:8888/#/datasource/list"*