### PR TITLE
[Fix-4293][UI] Fix data loss in switched tab

### DIFF
--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,4 +1,4 @@
-Apache DolphinScheduler (incubating) is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+Apache DolphinScheduler is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator.
 Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, 
 communications, and decision making process have stabilized in a manner consistent with other successful ASF projects. 
 While incubation status is not necessarily a reflection of the completeness or stability of the code, 

--- a/dolphinscheduler-ui/src/js/conf/home/App.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/App.vue
@@ -42,7 +42,7 @@
     },
     mounted () {
       visibility.change((evt, hidden) => {
-        if (hidden === false) {
+        if (hidden === false && this.$route.meta.refesh_in_switched_tab) {
           this.reload()
         }
       })

--- a/dolphinscheduler-ui/src/js/conf/home/router/index.js
+++ b/dolphinscheduler-ui/src/js/conf/home/router/index.js
@@ -35,7 +35,8 @@ const router = new Router({
       name: 'home',
       component: resolve => require(['../pages/home/index'], resolve),
       meta: {
-        title: `${i18n.$t('Home')} - DolphinScheduler`
+        title: `${i18n.$t('Home')} - DolphinScheduler`,
+        refesh_in_switched_tab: true
       }
     },
     {
@@ -54,7 +55,8 @@ const router = new Router({
           name: 'projects-index',
           component: resolve => require(['../pages/projects/pages/index/index'], resolve),
           meta: {
-            title: `${i18n.$t('Project Home')}`
+            title: `${i18n.$t('Project Home')}`,
+            refesh_in_switched_tab: true
           }
         },
         {
@@ -62,7 +64,8 @@ const router = new Router({
           name: 'projects-kinship',
           component: resolve => require(['../pages/projects/pages/kinship/index'], resolve),
           meta: {
-            title: `${i18n.$t('Kinship')}`
+            title: `${i18n.$t('Kinship')}`,
+            refesh_in_switched_tab: true
           }
         },
         {
@@ -70,7 +73,8 @@ const router = new Router({
           name: 'projects-list',
           component: resolve => require(['../pages/projects/pages/list/index'], resolve),
           meta: {
-            title: `${i18n.$t('Project')}`
+            title: `${i18n.$t('Project')}`,
+            refesh_in_switched_tab: true
           }
         },
         {
@@ -78,7 +82,8 @@ const router = new Router({
           name: 'definition',
           component: resolve => require(['../pages/projects/pages/definition/index'], resolve),
           meta: {
-            title: `${i18n.$t('Process definition')}`
+            title: `${i18n.$t('Process definition')}`,
+            refesh_in_switched_tab: true
           },
           redirect: {
             name: 'projects-definition-list'
@@ -89,7 +94,8 @@ const router = new Router({
               name: 'projects-definition-list',
               component: resolve => require(['../pages/projects/pages/definition/pages/list/index'], resolve),
               meta: {
-                title: `${i18n.$t('Process definition')}`
+                title: `${i18n.$t('Process definition')}`,
+                refesh_in_switched_tab: true
               }
             },
             {
@@ -97,7 +103,8 @@ const router = new Router({
               name: 'projects-definition-details',
               component: resolve => require(['../pages/projects/pages/definition/pages/details/index'], resolve),
               meta: {
-                title: `${i18n.$t('Process definition details')}`
+                title: `${i18n.$t('Process definition details')}`,
+                refesh_in_switched_tab: true
               }
             },
             {
@@ -113,7 +120,8 @@ const router = new Router({
               name: 'definition-tree-view-index',
               component: resolve => require(['../pages/projects/pages/definition/pages/tree/index'], resolve),
               meta: {
-                title: `${i18n.$t('TreeView')}`
+                title: `${i18n.$t('TreeView')}`,
+                refesh_in_switched_tab: true
               }
             },
             {
@@ -121,7 +129,8 @@ const router = new Router({
               name: 'definition-timing-details',
               component: resolve => require(['../pages/projects/pages/definition/timing/index'], resolve),
               meta: {
-                title: `${i18n.$t('Scheduled task list')}`
+                title: `${i18n.$t('Scheduled task list')}`,
+                refesh_in_switched_tab: true
               }
             }
           ]
@@ -142,7 +151,8 @@ const router = new Router({
               name: 'projects-instance-list',
               component: resolve => require(['../pages/projects/pages/instance/pages/list/index'], resolve),
               meta: {
-                title: `${i18n.$t('Process Instance')}`
+                title: `${i18n.$t('Process Instance')}`,
+                refesh_in_switched_tab: true
               }
             },
             {
@@ -150,7 +160,8 @@ const router = new Router({
               name: 'projects-instance-details',
               component: resolve => require(['../pages/projects/pages/instance/pages/details/index'], resolve),
               meta: {
-                title: `${i18n.$t('Process instance details')}`
+                title: `${i18n.$t('Process instance details')}`,
+                refesh_in_switched_tab: true
               }
             },
             {
@@ -158,7 +169,8 @@ const router = new Router({
               name: 'instance-gantt-index',
               component: resolve => require(['../pages/projects/pages/instance/pages/gantt/index'], resolve),
               meta: {
-                title: `${i18n.$t('Gantt')}`
+                title: `${i18n.$t('Gantt')}`,
+                refesh_in_switched_tab: true
               }
             }
           ]
@@ -168,7 +180,8 @@ const router = new Router({
           name: 'task-instance',
           component: resolve => require(['../pages/projects/pages/taskInstance'], resolve),
           meta: {
-            title: `${i18n.$t('Task Instance')}`
+            title: `${i18n.$t('Task Instance')}`,
+            refesh_in_switched_tab: true
           }
 
         },
@@ -177,7 +190,8 @@ const router = new Router({
           name: 'task-record',
           component: resolve => require(['../pages/projects/pages/taskRecord'], resolve),
           meta: {
-            title: `${i18n.$t('Task record')}`
+            title: `${i18n.$t('Task record')}`,
+            refesh_in_switched_tab: true
           }
         },
         {
@@ -185,7 +199,8 @@ const router = new Router({
           name: 'history-task-record',
           component: resolve => require(['../pages/projects/pages/historyTaskRecord'], resolve),
           meta: {
-            title: `${i18n.$t('History task record')}`
+            title: `${i18n.$t('History task record')}`,
+            refesh_in_switched_tab: true
           }
 
         }
@@ -199,7 +214,8 @@ const router = new Router({
         name: 'file'
       },
       meta: {
-        title: `${i18n.$t('Resources')}`
+        title: `${i18n.$t('Resources')}`,
+        refesh_in_switched_tab: true
       },
       children: [
         {
@@ -207,7 +223,8 @@ const router = new Router({
           name: 'file',
           component: resolve => require(['../pages/resource/pages/file/pages/list/index'], resolve),
           meta: {
-            title: `${i18n.$t('File Manage')}`
+            title: `${i18n.$t('File Manage')}`,
+            refesh_in_switched_tab: true
           }
         },
         {
@@ -231,7 +248,8 @@ const router = new Router({
           name: 'resource-file-subFileFolder',
           component: resolve => require(['../pages/resource/pages/file/pages/subFileFolder/index'], resolve),
           meta: {
-            title: `${i18n.$t('Create Resource')}`
+            title: `${i18n.$t('Create Resource')}`,
+            refesh_in_switched_tab: true
           }
         },
         {
@@ -239,7 +257,8 @@ const router = new Router({
           name: 'resource-file-subFile',
           component: resolve => require(['../pages/resource/pages/file/pages/subFile/index'], resolve),
           meta: {
-            title: `${i18n.$t('Create Resource')}`
+            title: `${i18n.$t('Create Resource')}`,
+            refesh_in_switched_tab: true
           }
         },
         {
@@ -247,7 +266,8 @@ const router = new Router({
           name: 'resource-file-details',
           component: resolve => require(['../pages/resource/pages/file/pages/details/index'], resolve),
           meta: {
-            title: `${i18n.$t('File Details')}`
+            title: `${i18n.$t('File Details')}`,
+            refesh_in_switched_tab: true
           }
         },
         {
@@ -255,7 +275,8 @@ const router = new Router({
           name: 'resource-file-subdirectory',
           component: resolve => require(['../pages/resource/pages/file/pages/subdirectory/index'], resolve),
           meta: {
-            title: `${i18n.$t('File Manage')}`
+            title: `${i18n.$t('File Manage')}`,
+            refesh_in_switched_tab: true
           }
         },
         {
@@ -271,7 +292,8 @@ const router = new Router({
           name: 'udf',
           component: resolve => require(['../pages/resource/pages/udf/index'], resolve),
           meta: {
-            title: `${i18n.$t('UDF manage')}`
+            title: `${i18n.$t('UDF manage')}`,
+            refesh_in_switched_tab: true
           },
           children: [
             {
@@ -279,7 +301,8 @@ const router = new Router({
               name: 'resource-udf',
               component: resolve => require(['../pages/resource/pages/udf/pages/resource/index'], resolve),
               meta: {
-                title: `${i18n.$t('UDF Resources')}`
+                title: `${i18n.$t('UDF Resources')}`,
+                refesh_in_switched_tab: true
               }
             },
             {
@@ -287,7 +310,8 @@ const router = new Router({
               name: 'resource-udf-subUdfDirectory',
               component: resolve => require(['../pages/resource/pages/udf/pages/subUdfDirectory/index'], resolve),
               meta: {
-                title: `${i18n.$t('UDF Resources')}`
+                title: `${i18n.$t('UDF Resources')}`,
+                refesh_in_switched_tab: true
               }
             },
             {
@@ -453,7 +477,8 @@ const router = new Router({
           name: 'servers-master',
           component: resolve => require(['../pages/monitor/pages/servers/master'], resolve),
           meta: {
-            title: `${i18n.$t('Service-Master')}`
+            title: `${i18n.$t('Service-Master')}`,
+            refesh_in_switched_tab: true
           }
         },
         {
@@ -461,7 +486,8 @@ const router = new Router({
           name: 'servers-worker',
           component: resolve => require(['../pages/monitor/pages/servers/worker'], resolve),
           meta: {
-            title: `${i18n.$t('Service-Worker')}`
+            title: `${i18n.$t('Service-Worker')}`,
+            refesh_in_switched_tab: true
           }
         },
         {
@@ -469,7 +495,8 @@ const router = new Router({
           name: 'servers-alert',
           component: resolve => require(['../pages/monitor/pages/servers/alert'], resolve),
           meta: {
-            title: 'Alert'
+            title: 'Alert',
+            refesh_in_switched_tab: true
           }
         },
         {
@@ -477,7 +504,8 @@ const router = new Router({
           name: 'servers-rpcserver',
           component: resolve => require(['../pages/monitor/pages/servers/rpcserver'], resolve),
           meta: {
-            title: 'Rpcserver'
+            title: 'Rpcserver',
+            refesh_in_switched_tab: true
           }
         },
         {
@@ -485,7 +513,8 @@ const router = new Router({
           name: 'servers-zookeeper',
           component: resolve => require(['../pages/monitor/pages/servers/zookeeper'], resolve),
           meta: {
-            title: 'Zookeeper'
+            title: 'Zookeeper',
+            refesh_in_switched_tab: true
           }
         },
         {
@@ -493,7 +522,8 @@ const router = new Router({
           name: 'servers-apiserver',
           component: resolve => require(['../pages/monitor/pages/servers/apiserver'], resolve),
           meta: {
-            title: 'Apiserver'
+            title: 'Apiserver',
+            refesh_in_switched_tab: true
           }
         },
         {
@@ -501,7 +531,8 @@ const router = new Router({
           name: 'servers-db',
           component: resolve => require(['../pages/monitor/pages/servers/db'], resolve),
           meta: {
-            title: 'DB'
+            title: 'DB',
+            refesh_in_switched_tab: true
           }
         },
         {
@@ -509,7 +540,8 @@ const router = new Router({
           name: 'statistics',
           component: resolve => require(['../pages/monitor/pages/servers/statistics'], resolve),
           meta: {
-            title: 'statistics'
+            title: 'statistics',
+            refesh_in_switched_tab: true
           }
         }
       ]


### PR DESCRIPTION
## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

## What is the purpose of the pull request

Fix data loss in switched tab
This closes #4293

## Brief change log

  - *Add `refesh_in_switched_tab` in router meta*
  - *Set `refesh_in_switched_tab: true` in detail and list page which needs to refresh*

## Verify this pull request

*(Please pick either of the following options)*

This change added tests and can be verified as follows:

*(example:)*

  - *Manually verified the change by testing locally.*
