### PR TITLE
[Fix-4455][common] fix parse shell output

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/shell/ShellExecutor.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/shell/ShellExecutor.java
@@ -140,8 +140,8 @@ public class ShellExecutor extends AbstractShell {
         String line = "";
         while ( (nRead = lines.read(buf, 0, buf.length)) > 0 ) {
             line = new String(buf,0,nRead);
+            output.append(line);
         }
-        output.append(line);
     }
 
     /**


### PR DESCRIPTION
## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

## What is the purpose of the pull request

- Fix: kill task error because of shell output truncation （由于shell 输出截断，导致kill任务失败)

- This closes #4455 

## Brief change log

- In the common module, fix the problem of truncation exceeding buf when the shell script is executed to obtain the output, and only the last time is retained
- common 模块中，修复执行 shell 脚本获取输出时超过buf的截断，仅保留最后一次的问题
## Verify this pull request

  - *Manually verified the change by testing locally.*
  - *The local production environment verified*
