### PR TITLE
[fix-4472][DataSource] Hive JDBC partial permission parameter concatenation JDBC URL error

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HiveConfUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/HiveConfUtils.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dolphinscheduler.common.utils;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * hive conf utils
+ */
+public class HiveConfUtils {
+
+    private HiveConfUtils() {
+        throw new UnsupportedOperationException("Construct HiveConfUtils");
+    }
+
+    private static class HiveConfHandler {
+        private static HiveConf singleton;
+
+        private static Map<String,Object> hiveConfVars;
+
+        static {
+            singleton = new HiveConf();
+            hiveConfVars = new HashMap<>();
+            Arrays.stream(ConfVars.values()).forEach(confVar -> hiveConfVars.put(confVar.varname,confVar));
+        }
+    }
+
+    /**
+     * get HiveConf instance
+     * @return HiveConf hiveConf
+     */
+    public static HiveConf getInstance() {
+        return HiveConfHandler.singleton;
+    }
+
+    /**
+     * get hive conf vars
+     * @return
+     */
+    public static Map<String,Object> getHiveConfVars() {
+        return HiveConfHandler.hiveConfVars;
+    }
+
+    /**
+     * Determine if it belongs to a hive conf property
+     * @param conf config
+     * @return boolean result
+     */
+    public static boolean isHiveConfVar(String conf) {
+        // the default hive conf var name
+        String confKey = conf.split("=")[0];
+        Map<String, Object> hiveConfVars = HiveConfUtils.getHiveConfVars();
+        if (hiveConfVars.get(confKey) != null) {
+            return true;
+        }
+
+        // the security authorization hive conf var name
+        HiveConf hiveConf = HiveConfUtils.getInstance();
+        String hiveAuthorizationSqlStdAuthConfigWhitelist = hiveConf.getVar(HiveConf.ConfVars.HIVE_AUTHORIZATION_SQL_STD_AUTH_CONFIG_WHITELIST);
+        Pattern modWhiteListPattern = Pattern.compile(hiveAuthorizationSqlStdAuthConfigWhitelist);
+        Matcher matcher = modWhiteListPattern.matcher(confKey);
+        return matcher.matches();
+    }
+
+}

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/HiveConfUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/HiveConfUtilsTest.java
@@ -1,0 +1,30 @@
+package org.apache.dolphinscheduler.common.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * hive conf utils test
+ */
+public class HiveConfUtilsTest {
+
+    /**
+     * test is hive conf var
+     */
+    @Test
+    public void testIsHiveConfVar() {
+
+        String conf = "hive.exec.script.wrapper=123";
+        boolean hiveConfVar = HiveConfUtils.isHiveConfVar(conf);
+        Assert.assertTrue(hiveConfVar);
+
+        conf = "hive.test.v1=v1";
+        hiveConfVar = HiveConfUtils.isHiveConfVar(conf);
+        Assert.assertFalse(hiveConfVar);
+
+        conf = "tez.queue.name=tezQueue";
+        hiveConfVar = HiveConfUtils.isHiveConfVar(conf);
+        Assert.assertTrue(hiveConfVar);
+
+    }
+}

--- a/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/HiveConfUtilsTest.java
+++ b/dolphinscheduler-common/src/test/java/org/apache/dolphinscheduler/common/utils/HiveConfUtilsTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.dolphinscheduler.common.utils;
 
 import org.junit.Assert;

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/datasource/HiveDataSource.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/datasource/HiveDataSource.java
@@ -19,78 +19,71 @@ package org.apache.dolphinscheduler.dao.datasource;
 
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.DbType;
+import org.apache.dolphinscheduler.common.utils.HiveConfUtils;
 import org.apache.dolphinscheduler.common.utils.StringUtils;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 
 /**
  * data source of hive
  */
 public class HiveDataSource extends BaseDataSource {
 
-  /**
-   * gets the JDBC url for the data source connection
-   * @return jdbc url
-   */
-  @Override
-  public String driverClassSelector() {
-    return Constants.ORG_APACHE_HIVE_JDBC_HIVE_DRIVER;
-  }
-
-  /**
-   * @return db type
-   */
-  @Override
-  public DbType dbTypeSelector() {
-    return DbType.HIVE;
-  }
-
-  /**
-   * build hive jdbc params,append : ?hive_conf_list
-   *
-   * hive jdbc url template:
-   *
-   * jdbc:hive2://<host1>:<port1>,<host2>:<port2>/dbName;initFile=<file>;sess_var_list?hive_conf_list#hive_var_list
-   *
-   * @param otherParams otherParams
-   * @return filter otherParams
-   */
-  @Override
-  protected String filterOther(String otherParams) {
-    if (StringUtils.isBlank(otherParams)) {
-      return "";
+    /**
+     * gets the JDBC url for the data source connection
+     * @return jdbc url
+     */
+    @Override
+    public String driverClassSelector() {
+        return Constants.ORG_APACHE_HIVE_JDBC_HIVE_DRIVER;
     }
 
-    StringBuilder hiveConfListSb = new StringBuilder();
-    hiveConfListSb.append("?");
-    StringBuilder sessionVarListSb = new StringBuilder();
-
-    String[] otherArray = otherParams.split(";", -1);
-
-    // get the default hive conf var name
-    Set<String> hiveConfSet = Stream.of(ConfVars.values()).map(confVars -> confVars.varname)
-        .collect(Collectors.toSet());
-
-    for (String conf : otherArray) {
-      if (hiveConfSet.contains(conf.split("=")[0])) {
-        hiveConfListSb.append(conf).append(";");
-      } else {
-        sessionVarListSb.append(conf).append(";");
-      }
+    /**
+     * @return db type
+     */
+    @Override
+    public DbType dbTypeSelector() {
+        return DbType.HIVE;
     }
 
-    // remove the last ";"
-    if (sessionVarListSb.length() > 0) {
-      sessionVarListSb.deleteCharAt(sessionVarListSb.length() - 1);
-    }
+    /**
+     * build hive jdbc params,append : ?hive_conf_list
+     *
+     * hive jdbc url template:
+     *
+     * jdbc:hive2://<host1>:<port1>,<host2>:<port2>/dbName;initFile=<file>;sess_var_list?hive_conf_list#hive_var_list
+     *
+     * @param otherParams otherParams
+     * @return filter otherParams
+     */
+    @Override
+    protected String filterOther(String otherParams) {
+        if (StringUtils.isBlank(otherParams)) {
+            return "";
+        }
 
-    if (hiveConfListSb.length() > 0) {
-      hiveConfListSb.deleteCharAt(hiveConfListSb.length() - 1);
-    }
+        StringBuilder hiveConfListSb = new StringBuilder();
+        hiveConfListSb.append("?");
+        StringBuilder sessionVarListSb = new StringBuilder();
 
-    return sessionVarListSb.toString() + hiveConfListSb.toString();
-  }
+        String[] otherArray = otherParams.split(";", -1);
+
+        for (String conf : otherArray) {
+            if (HiveConfUtils.isHiveConfVar(conf)) {
+                hiveConfListSb.append(conf).append(";");
+            } else {
+                sessionVarListSb.append(conf).append(";");
+            }
+        }
+
+        // remove the last ";"
+        if (sessionVarListSb.length() > 0) {
+            sessionVarListSb.deleteCharAt(sessionVarListSb.length() - 1);
+        }
+
+        if (hiveConfListSb.length() > 0) {
+            hiveConfListSb.deleteCharAt(hiveConfListSb.length() - 1);
+        }
+
+        return sessionVarListSb.toString() + hiveConfListSb.toString();
+    }
   
 }

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/datasource/HiveDataSourceTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/datasource/HiveDataSourceTest.java
@@ -25,66 +25,66 @@ import org.junit.Test;
  */
 public class HiveDataSourceTest {
 
-  @Test
-  public void testFilterOther() {
-    BaseDataSource hiveDataSource = new HiveDataSource();
+    @Test
+    public void testFilterOther() {
+        BaseDataSource hiveDataSource = new HiveDataSource();
 
-    // not contain hive_site_conf
-    String other = hiveDataSource.filterOther("charset=UTF-8");
-    Assert.assertEquals("charset=UTF-8", other);
+        // not contain hive_site_conf
+        String other = hiveDataSource.filterOther("charset=UTF-8");
+        Assert.assertEquals("charset=UTF-8", other);
 
-    // not contain
-    other = hiveDataSource.filterOther("");
-    Assert.assertEquals("", other);
+        // not contain
+        other = hiveDataSource.filterOther("");
+        Assert.assertEquals("", other);
 
-    // only contain hive_site_conf
-    other = hiveDataSource.filterOther("hive.mapred.mode=strict");
-    Assert.assertEquals("?hive.mapred.mode=strict", other);
+        // only contain hive_site_conf
+        other = hiveDataSource.filterOther("hive.mapred.mode=strict");
+        Assert.assertEquals("?hive.mapred.mode=strict", other);
 
-    // contain hive_site_conf at the first
-    other = hiveDataSource.filterOther("hive.mapred.mode=strict;charset=UTF-8");
-    Assert.assertEquals("charset=UTF-8?hive.mapred.mode=strict", other);
+        // contain hive_site_conf at the first
+        other = hiveDataSource.filterOther("hive.mapred.mode=strict;charset=UTF-8");
+        Assert.assertEquals("charset=UTF-8?hive.mapred.mode=strict", other);
 
-    // contain hive_site_conf in the middle
-    other = hiveDataSource.filterOther("charset=UTF-8;hive.mapred.mode=strict;foo=bar");
-    Assert.assertEquals("charset=UTF-8;foo=bar?hive.mapred.mode=strict", other);
+        // contain hive_site_conf in the middle
+        other = hiveDataSource.filterOther("charset=UTF-8;hive.mapred.mode=strict;foo=bar");
+        Assert.assertEquals("charset=UTF-8;foo=bar?hive.mapred.mode=strict", other);
 
-    // contain hive_site_conf at the end
-    other = hiveDataSource.filterOther("charset=UTF-8;foo=bar;hive.mapred.mode=strict");
-    Assert.assertEquals("charset=UTF-8;foo=bar?hive.mapred.mode=strict", other);
+        // contain hive_site_conf at the end
+        other = hiveDataSource.filterOther("charset=UTF-8;foo=bar;hive.mapred.mode=strict");
+        Assert.assertEquals("charset=UTF-8;foo=bar?hive.mapred.mode=strict", other);
 
-    // contain multi hive_site_conf
-    other = hiveDataSource.filterOther("charset=UTF-8;foo=bar;hive.mapred.mode=strict;hive.exec.parallel=true");
-    Assert.assertEquals("charset=UTF-8;foo=bar?hive.mapred.mode=strict;hive.exec.parallel=true", other);
+        // contain multi hive_site_conf
+        other = hiveDataSource.filterOther("charset=UTF-8;foo=bar;hive.mapred.mode=strict;hive.exec.parallel=true");
+        Assert.assertEquals("charset=UTF-8;foo=bar?hive.mapred.mode=strict;hive.exec.parallel=true", other);
 
-    // the security authorization hive conf var
-    other = hiveDataSource.filterOther("tez.queue.name=tezTest");
-    Assert.assertEquals("?tez.queue.name=tezTest", other);
+        // the security authorization hive conf var
+        other = hiveDataSource.filterOther("tez.queue.name=tezTest");
+        Assert.assertEquals("?tez.queue.name=tezTest", other);
 
-  }
+    }
 
-  @Test
-  public void testGetHiveJdbcUrlOther() {
+    @Test
+    public void testGetHiveJdbcUrlOther() {
 
-    BaseDataSource hiveDataSource = new HiveDataSource();
-    hiveDataSource.setAddress("jdbc:hive2://127.0.0.1:10000");
-    hiveDataSource.setDatabase("test");
-    hiveDataSource.setPassword("123456");
-    hiveDataSource.setUser("test");
-    Assert.assertEquals("jdbc:hive2://127.0.0.1:10000/test", hiveDataSource.getJdbcUrl());
+        BaseDataSource hiveDataSource = new HiveDataSource();
+        hiveDataSource.setAddress("jdbc:hive2://127.0.0.1:10000");
+        hiveDataSource.setDatabase("test");
+        hiveDataSource.setPassword("123456");
+        hiveDataSource.setUser("test");
+        Assert.assertEquals("jdbc:hive2://127.0.0.1:10000/test", hiveDataSource.getJdbcUrl());
 
-    hiveDataSource.setOther("charset=UTF-8;hive.mapred.mode=strict;hive.server2.thrift.http.path=hs2");
+        hiveDataSource.setOther("charset=UTF-8;hive.mapred.mode=strict;hive.server2.thrift.http.path=hs2");
 
-    Assert.assertEquals(
-            "jdbc:hive2://127.0.0.1:10000/test;charset=UTF-8?hive.mapred.mode=strict;hive.server2.thrift.http.path=hs2",
-            hiveDataSource.getJdbcUrl());
+        Assert.assertEquals(
+                "jdbc:hive2://127.0.0.1:10000/test;charset=UTF-8?hive.mapred.mode=strict;hive.server2.thrift.http.path=hs2",
+                hiveDataSource.getJdbcUrl());
 
-    hiveDataSource.setOther("hive.mapred.mode=strict;hive.server2.thrift.http.path=hs2");
+        hiveDataSource.setOther("hive.mapred.mode=strict;hive.server2.thrift.http.path=hs2");
 
-    Assert.assertEquals(
-            "jdbc:hive2://127.0.0.1:10000/test;?hive.mapred.mode=strict;hive.server2.thrift.http.path=hs2",
-            hiveDataSource.getJdbcUrl());
+        Assert.assertEquals(
+                "jdbc:hive2://127.0.0.1:10000/test;?hive.mapred.mode=strict;hive.server2.thrift.http.path=hs2",
+                hiveDataSource.getJdbcUrl());
 
-  }
+    }
 
 }

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/datasource/HiveDataSourceTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/datasource/HiveDataSourceTest.java
@@ -80,7 +80,6 @@ public class HiveDataSourceTest {
                 hiveDataSource.getJdbcUrl());
 
         hiveDataSource.setOther("hive.mapred.mode=strict;hive.server2.thrift.http.path=hs2");
-
         Assert.assertEquals(
                 "jdbc:hive2://127.0.0.1:10000/test;?hive.mapred.mode=strict;hive.server2.thrift.http.path=hs2",
                 hiveDataSource.getJdbcUrl());

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/datasource/HiveDataSourceTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/datasource/HiveDataSourceTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 public class HiveDataSourceTest {
 
   @Test
-  public void testfilterOther() {
+  public void testFilterOther() {
     BaseDataSource hiveDataSource = new HiveDataSource();
 
     // not contain hive_site_conf

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/datasource/HiveDataSourceTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/datasource/HiveDataSourceTest.java
@@ -56,6 +56,11 @@ public class HiveDataSourceTest {
     // contain multi hive_site_conf
     other = hiveDataSource.filterOther("charset=UTF-8;foo=bar;hive.mapred.mode=strict;hive.exec.parallel=true");
     Assert.assertEquals("charset=UTF-8;foo=bar?hive.mapred.mode=strict;hive.exec.parallel=true", other);
+
+    // the security authorization hive conf var
+    other = hiveDataSource.filterOther("tez.queue.name=tezTest");
+    Assert.assertEquals("?tez.queue.name=tezTest", other);
+
   }
 
   @Test
@@ -71,14 +76,14 @@ public class HiveDataSourceTest {
     hiveDataSource.setOther("charset=UTF-8;hive.mapred.mode=strict;hive.server2.thrift.http.path=hs2");
 
     Assert.assertEquals(
-        "jdbc:hive2://127.0.0.1:10000/test;charset=UTF-8?hive.mapred.mode=strict;hive.server2.thrift.http.path=hs2",
-        hiveDataSource.getJdbcUrl());
+            "jdbc:hive2://127.0.0.1:10000/test;charset=UTF-8?hive.mapred.mode=strict;hive.server2.thrift.http.path=hs2",
+            hiveDataSource.getJdbcUrl());
 
     hiveDataSource.setOther("hive.mapred.mode=strict;hive.server2.thrift.http.path=hs2");
 
     Assert.assertEquals(
-        "jdbc:hive2://127.0.0.1:10000/test;?hive.mapred.mode=strict;hive.server2.thrift.http.path=hs2",
-        hiveDataSource.getJdbcUrl());
+            "jdbc:hive2://127.0.0.1:10000/test;?hive.mapred.mode=strict;hive.server2.thrift.http.path=hs2",
+            hiveDataSource.getJdbcUrl());
 
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -790,6 +790,7 @@
                         <include>**/common/utils/HadoopUtilsTest.java</include>
                         <include>**/common/utils/HttpUtilsTest.java</include>
                         <include>**/common/utils/KerberosHttpClientTest.java</include>
+                        <include>**/common/utils/HiveConfUtilsTest.java</include>
                         <include>**/common/ConstantsTest.java</include>
                         <include>**/common/utils/HadoopUtils.java</include>
                         <include>**/common/utils/RetryerUtilsTest.java</include>


### PR DESCRIPTION

## What is the purpose of the pull request
this PR closes #4472

Solve the problem of parameter splicing of permission part in Hive JDBC URL, such as parameter: tez.queue.name=tqn The spliced JDBC URL is jdbc:hive2://:,:/dbName;tez.queue.name=tqn, and the normal JDBC URL is jdbc:hive2://:,:/dbName?tez.queue.name=tqn

## Brief change log

update HiveDataSource.filterOther()

## Verify this pull request

- HiveConfUtilsTest
- HiveDataSourceTest
