### PR TITLE
[Feature-4463][UI]: Add an option to the UI page for saving the workflow definition: whether to go online?

### DIFF
--- a/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/udp/udp.vue
+++ b/dolphinscheduler-ui/src/js/conf/home/pages/dag/_source/udp/udp.vue
@@ -74,6 +74,11 @@
     </div>
     <div class="bottom">
       <div class="submit">
+        <template v-if="router.history.current.name === 'projects-definition-details'">
+          <div class="lint-pt">
+            <el-checkbox v-model="releaseState" size="small" :false-label="0" :true-label="1">{{$t('Whether to go online the process definition')}}</el-checkbox>
+          </div>
+        </template>
         <template v-if="router.history.current.name === 'projects-instance-details'">
           <div class="lint-pt">
             <el-checkbox v-model="syncDefine" size="small">{{$t('Whether to update the process definition')}}</el-checkbox>
@@ -106,6 +111,8 @@
         udpList: [],
         // Global custom parameters
         udpListCache: [],
+        // Whether to go online the process definition
+        releaseState: 1,
         // Whether to update the process definition
         syncDefine: true,
         // Timeout alarm
@@ -141,6 +148,7 @@
         this.store.commit('dag/setTenantId', _.cloneDeep(this.tenantId))
         this.store.commit('dag/setDesc', _.cloneDeep(this.description))
         this.store.commit('dag/setSyncDefine', this.syncDefine)
+        this.store.commit('dag/setReleaseState', this.releaseState)
       },
       /**
        * submit
@@ -201,6 +209,7 @@
       this.originalName = dag.name
       this.description = dag.description
       this.syncDefine = dag.syncDefine
+      this.releaseState = dag.releaseState
       this.timeout = dag.timeout || 0
       this.checkedTimeout = this.timeout !== 0
       this.$nextTick(() => {

--- a/dolphinscheduler-ui/src/js/conf/home/store/dag/actions.js
+++ b/dolphinscheduler-ui/src/js/conf/home/store/dag/actions.js
@@ -318,7 +318,8 @@ export default {
         connects: JSON.stringify(state.connects),
         name: _.trim(state.name),
         description: _.trim(state.description),
-        id: payload
+        id: payload,
+        releaseState: state.releaseState
       }, res => {
         resolve(res)
         state.isEditDag = false

--- a/dolphinscheduler-ui/src/js/conf/home/store/dag/mutations.js
+++ b/dolphinscheduler-ui/src/js/conf/home/store/dag/mutations.js
@@ -75,6 +75,9 @@ export default {
   setDesc (state, payload) {
     state.description = payload
   },
+  setReleaseState (state, payload) {
+    state.releaseState = payload
+  },
   /**
    * Whether to update the process definition
    */

--- a/dolphinscheduler-ui/src/js/conf/home/store/dag/state.js
+++ b/dolphinscheduler-ui/src/js/conf/home/store/dag/state.js
@@ -45,6 +45,8 @@ export default {
   isEditDag: false,
   // Current project
   projectName: projectName || '',
+  // Whether to go online the process definition
+  releaseState: 1,
   // Whether to update the process definition
   syncDefine: true,
   // tasks processList

--- a/dolphinscheduler-ui/src/js/module/i18n/locale/en_US.js
+++ b/dolphinscheduler-ui/src/js/module/i18n/locale/en_US.js
@@ -64,6 +64,7 @@ export default {
   'Set the DAG diagram name': 'Set the DAG diagram name',
   'Please enter description(optional)': 'Please enter description(optional)',
   'Set global': 'Set global',
+  'Whether to go online the process definition': 'Whether to go online the process definition',
   'Whether to update the process definition': 'Whether to update the process definition',
   Add: 'Add',
   'DAG graph name cannot be empty': 'DAG graph name cannot be empty',

--- a/dolphinscheduler-ui/src/js/module/i18n/locale/zh_CN.js
+++ b/dolphinscheduler-ui/src/js/module/i18n/locale/zh_CN.js
@@ -64,6 +64,7 @@ export default {
   'Set the DAG diagram name': '设置DAG图名称',
   'Please enter description(optional)': '请输入描述(选填)',
   'Set global': '设置全局',
+  'Whether to go online the process definition': '是否上线流程定义',
   'Whether to update the process definition': '是否更新流程定义',
   Add: '添加',
   'DAG graph name cannot be empty': 'DAG图名称不能为空',


### PR DESCRIPTION
## What is the purpose of the pull request

Implement UI #4463 

this close #4463 

## Brief change log
- Add variable 'releaseState', which indicates whether to go online or not. 0 means not to go online, 1 means online, online by default
- Add a checkbox option and show it when saving the workflow definition in detail page
- Add 'releaseState' param in 'updateDefinition' action method

## Verify this pull request
- Manually verified the change by testing locally.
![image](https://user-images.githubusercontent.com/35388422/104806315-93a9d000-5811-11eb-8551-36ccadb3f6ac.png)

