### PR TITLE
[Improvement-#4503][dolphinscheduler-dist]Jackson version upgraded to 2.10.5 from 2.9.10

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/JSONUtils.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/utils/JSONUtils.java
@@ -294,7 +294,11 @@ public class JSONUtils {
 
     public static ObjectNode parseObject(String text) {
         try {
-            return (ObjectNode) objectMapper.readTree(text);
+            if (text.isEmpty()) {
+                return parseObject(text, ObjectNode.class);
+            } else {
+                return (ObjectNode) objectMapper.readTree(text);
+            }
         } catch (Exception e) {
             throw new RuntimeException("String json deserialization exception.", e);
         }

--- a/dolphinscheduler-dist/release-docs/LICENSE
+++ b/dolphinscheduler-dist/release-docs/LICENSE
@@ -286,10 +286,10 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     httpclient 4.4.1: https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient/4.4.1, Apache 2.0
     httpcore 4.4.1: https://mvnrepository.com/artifact/org.apache.httpcomponents/httpcore/4.4.1, Apache 2.0
     httpmime 4.5.7: https://mvnrepository.com/artifact/org.apache.httpcomponents/httpmime/4.5.7, Apache 2.0
-    jackson-annotations 2.9.10: https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations/2.9.10, Apache 2.0
-    jackson-core 2.9.10: https://github.com/FasterXML/jackson-core, Apache 2.0
+    jackson-annotations 2.10.5: https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations/2.10.5, Apache 2.0
+    jackson-core 2.10.5: https://github.com/FasterXML/jackson-core, Apache 2.0
     jackson-core-asl 1.9.13: https://mvnrepository.com/artifact/org.codehaus.jackson/jackson-core-asl/1.9.13, Apache 2.0
-    jackson-databind 2.9.10: https://github.com/FasterXML/jackson-databind, Apache 2.0
+    jackson-databind 2.10.5: https://github.com/FasterXML/jackson-databind, Apache 2.0
     jackson-datatype-jdk8 2.9.10: https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.9.10, Apache 2.0
     jackson-datatype-jsr310 2.9.10: https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.9.10, Apache 2.0
     jackson-jaxrs 1.9.13: https://mvnrepository.com/artifact/org.codehaus.jackson/jackson-jaxrs/1.9.13, Apache 2.0 and LGPL 2.1

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <logback.version>1.2.3</logback.version>
         <hadoop.version>2.7.3</hadoop.version>
         <quartz.version>2.3.0</quartz.version>
-        <jackson.version>2.9.10</jackson.version>
+        <jackson.version>2.10.5</jackson.version>
         <mybatis-plus.version>3.2.0</mybatis-plus.version>
         <mybatis.spring.version>2.0.1</mybatis.spring.version>
         <cron.utils.version>5.0.5</cron.utils.version>

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -76,10 +76,10 @@ htrace-core-3.1.0-incubating.jar
 httpclient-4.4.1.jar
 httpcore-4.4.1.jar
 httpmime-4.5.12.jar
-jackson-annotations-2.9.10.jar
-jackson-core-2.9.10.jar
+jackson-annotations-2.10.5.jar
+jackson-core-2.10.5.jar
 jackson-core-asl-1.9.13.jar
-jackson-databind-2.9.10.jar
+jackson-databind-2.10.5.jar
 jackson-datatype-jdk8-2.9.10.jar
 jackson-datatype-jsr310-2.9.10.jar
 jackson-jaxrs-1.9.13.jar


### PR DESCRIPTION
 Recommended upgrade version：2.10.5.1 from 2.9.10
----------------------------------------------------
jackson-annotations-2.10.5.jar
jackson-core-2.10.5.jar
jackson-databind-2.10.5.jar
jackson-datatype-jdk8-2.9.10.jar
jackson-datatype-jsr310-2.9.10.jar
jackson-module-parameter-names-2.9.10.jar