### PR TITLE
[Improvement][API] ProjectService queryAllProjectList API optimization

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/ProjectServiceImpl.java
@@ -24,6 +24,7 @@ import org.apache.dolphinscheduler.api.service.ProjectService;
 import org.apache.dolphinscheduler.api.utils.PageInfo;
 import org.apache.dolphinscheduler.common.Constants;
 import org.apache.dolphinscheduler.common.enums.UserType;
+import org.apache.dolphinscheduler.common.utils.CollectionUtils;
 import org.apache.dolphinscheduler.dao.entity.ProcessDefinition;
 import org.apache.dolphinscheduler.dao.entity.Project;
 import org.apache.dolphinscheduler.dao.entity.ProjectUser;
@@ -442,21 +443,13 @@ public class ProjectServiceImpl extends BaseService implements ProjectService {
      */
     public Map<String, Object> queryAllProjectList() {
         Map<String, Object> result = new HashMap<>();
-        List<Project> projects = projectMapper.selectList(null);
-        List<ProcessDefinition> processDefinitions = processDefinitionMapper.selectList(null);
-        if (projects != null) {
-            Set<Integer> set = new HashSet<>();
-            for (ProcessDefinition processDefinition : processDefinitions) {
-                set.add(processDefinition.getProjectId());
-            }
-            List<Project> tempDeletelist = new ArrayList<>();
-            for (Project project : projects) {
-                if (!set.contains(project.getId())) {
-                    tempDeletelist.add(project);
-                }
-            }
-            projects.removeAll(tempDeletelist);
+        List<Project> projects = new ArrayList<>();
+
+        List<Integer> projectIds = processDefinitionMapper.listProjectIds();
+        if (CollectionUtils.isNotEmpty(projectIds)) {
+            projects = projectMapper.selectBatchIds(projectIds);
         }
+
         result.put(Constants.DATA_LIST, projects);
         putMsg(result, Status.SUCCESS);
         return result;

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/ProjectServiceTest.java
@@ -32,6 +32,7 @@ import org.apache.dolphinscheduler.dao.mapper.ProjectMapper;
 import org.apache.dolphinscheduler.dao.mapper.ProjectUserMapper;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -319,9 +320,8 @@ public class ProjectServiceTest {
 
     @Test
     public void testQueryAllProjectList() {
-
-        Mockito.when(projectMapper.selectList(null)).thenReturn(getList());
-        Mockito.when(processDefinitionMapper.selectList(null)).thenReturn(getProcessDefinitions());
+        Mockito.when(processDefinitionMapper.listProjectIds()).thenReturn(getProjectIds());
+        Mockito.when(projectMapper.selectBatchIds(getProjectIds())).thenReturn(getList());
 
         Map<String, Object> result = projectService.queryAllProjectList();
         logger.info(result.toString());
@@ -386,6 +386,11 @@ public class ProjectServiceTest {
         list.add(processDefinition);
         return list;
     }
+
+    private List<Integer> getProjectIds() {
+        return Collections.singletonList(1);
+    }
+
 
     private String getDesc() {
         return "projectUserMapper.deleteProjectRelation(projectId,userId)projectUserMappe"

--- a/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/ProcessDefinitionMapper.java
+++ b/dolphinscheduler-dao/src/main/java/org/apache/dolphinscheduler/dao/mapper/ProcessDefinitionMapper.java
@@ -138,4 +138,10 @@ public interface ProcessDefinitionMapper extends BaseMapper<ProcessDefinition> {
      * @param version version
      */
     void updateVersionByProcessDefinitionId(@Param("processDefinitionId") int processDefinitionId, @Param("version") long version);
+
+    /**
+     * list all project ids
+     * @return project ids list
+     */
+    List<Integer> listProjectIds();
 }

--- a/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessDefinitionMapper.xml
+++ b/dolphinscheduler-dao/src/main/resources/org/apache/dolphinscheduler/dao/mapper/ProcessDefinitionMapper.xml
@@ -128,6 +128,12 @@
         WHERE user_id = #{userId} and release_state = 1 and resource_ids is not null and resource_ids != ''
     </select>
 
+    <select id="listProjectIds" resultType="java.lang.Integer">
+        SELECT DISTINCT(project_id) as project_id
+        FROM t_ds_process_definition
+    </select>
+
+
     <update id="updateVersionByProcessDefinitionId">
         update  t_ds_process_definition
         set version = #{version}

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/ProcessDefinitionMapperTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/ProcessDefinitionMapperTest.java
@@ -366,4 +366,12 @@ public class ProcessDefinitionMapperTest {
         ProcessDefinition processDefinition1 = processDefinitionMapper.selectById(processDefinition.getId());
         Assert.assertEquals(expectedVersion, processDefinition1.getVersion());
     }
+
+    @Test
+    public void listProjectIds(){
+        ProcessDefinition processDefinition = insertOne();
+        List<Integer> projectIds = processDefinitionMapper.listProjectIds();
+        Assert.assertNotNull(projectIds);
+    }
+
 }

--- a/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/ProcessDefinitionMapperTest.java
+++ b/dolphinscheduler-dao/src/test/java/org/apache/dolphinscheduler/dao/mapper/ProcessDefinitionMapperTest.java
@@ -368,7 +368,7 @@ public class ProcessDefinitionMapperTest {
     }
 
     @Test
-    public void listProjectIds(){
+    public void listProjectIds() {
         ProcessDefinition processDefinition = insertOne();
         List<Integer> projectIds = processDefinitionMapper.listProjectIds();
         Assert.assertNotNull(projectIds);


### PR DESCRIPTION
## What is the purpose of the pull request

Optimize the api *ProjectService.queryAllProjectList*.
It's not good to query all processDefinition list and pick the project ids in menmory.

## Brief change log

ProjectServiceImpl.java
  - Changed methord `queryAllProjectList`

ProjectServiceTest.java
  - Changed methord `testQueryAllProjectList`

ProcessDefinitionMapper.java
  - Added method `listProjectIds`

ProcessDefinitionMapper.xml
  - Added sql for `listProjectIds` mapper

ProcessDefinitionMapperTest.java
  - Added method `listProjectIds`

## Verify this pull request

This pull request is already covered by existing tests:

  - *ProjectServiceTest.testQueryAllProjectList*
  - *ProcessDefinitionMapperTest.listProjectIds*
