### PR TITLE
[Improvement][Api] Use WebUtils.getCookie instead of BaseService.getCookie

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/interceptor/LocaleChangeInterceptor.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/interceptor/LocaleChangeInterceptor.java
@@ -17,7 +17,6 @@
 
 package org.apache.dolphinscheduler.api.interceptor;
 
-import org.apache.dolphinscheduler.api.service.BaseService;
 import org.apache.dolphinscheduler.common.Constants;
 
 import java.util.Locale;
@@ -30,12 +29,13 @@ import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.lang.Nullable;
 import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import org.springframework.web.util.WebUtils;
 
 public class LocaleChangeInterceptor extends HandlerInterceptorAdapter {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-        Cookie cookie = BaseService.getCookie(request, Constants.LOCALE_LANGUAGE);
+        Cookie cookie = WebUtils.getCookie(request, Constants.LOCALE_LANGUAGE);
         if (cookie != null) {
             // Proceed in cookie
             return true;

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/BaseService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/BaseService.java
@@ -113,27 +113,6 @@ public class BaseService {
         return false;
     }
 
-
-    /**
-     * get cookie info by name
-     *
-     * @param request request
-     * @param name 'sessionId'
-     * @return get cookie info
-     */
-    public static Cookie getCookie(HttpServletRequest request, String name) {
-        Cookie[] cookies = request.getCookies();
-        if (cookies != null && cookies.length > 0) {
-            for (Cookie cookie : cookies) {
-                if (StringUtils.isNotEmpty(name) && name.equalsIgnoreCase(cookie.getName())) {
-                    return cookie;
-                }
-            }
-        }
-
-        return null;
-    }
-
     /**
      * create tenant dir if not exists
      *

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/SessionServiceImpl.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/impl/SessionServiceImpl.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.util.WebUtils;
 
 /**
  * session service implement
@@ -60,7 +61,7 @@ public class SessionServiceImpl extends BaseService implements SessionService {
         String sessionId = request.getHeader(Constants.SESSION_ID);
 
         if (StringUtils.isBlank(sessionId)) {
-            Cookie cookie = getCookie(request, Constants.SESSION_ID);
+            Cookie cookie = WebUtils.getCookie(request, Constants.SESSION_ID);
 
             if (cookie != null) {
                 sessionId = cookie.getValue();

--- a/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/BaseServiceTest.java
+++ b/dolphinscheduler-api/src/test/java/org/apache/dolphinscheduler/api/service/BaseServiceTest.java
@@ -94,20 +94,6 @@ public class BaseServiceTest {
         baseService.putMsg(result,Status.PROJECT_NOT_FOUNT,"test");
     }
     @Test
-    public void testGetCookie(){
-
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockCookie mockCookie = new MockCookie("userId","1");
-        request.setCookies(mockCookie);
-        //cookie is not null
-        Cookie cookie = BaseService.getCookie(request,"userId");
-        Assert.assertNotNull(cookie);
-        //cookie is null
-        cookie = BaseService.getCookie(request,"userName");
-        Assert.assertNull(cookie);
-
-    }
-    @Test
     public void testCreateTenantDirIfNotExists(){
 
         PowerMockito.mockStatic(HadoopUtils.class);


### PR DESCRIPTION
## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

## What is the purpose of the pull request

*Use WebUtils.getCookie instead of BaseService.getCookie*

## Brief change log

  - *Use WebUtils.getCookie instead of BaseService.getCookie*

## Verify this pull request

This change added tests and can be verified as follows:

*(example:)*

  - *Manually verified the change by testing locally.*
