### PR TITLE
[github][issue-template]remove issue label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,6 @@
 name: Bug report
 about: Create a report to help us improve
 title: "[Bug][Module Name] Bug title "
-labels: bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,6 @@
 name: Feature request
 about: Suggest an idea for this project
 title: "[Feature][Module Name] Feature title"
-labels: new feature
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/improvement_suggestion.md
+++ b/.github/ISSUE_TEMPLATE/improvement_suggestion.md
@@ -2,7 +2,6 @@
 name: Improvement suggestion
 about: Improvement suggestion for this project
 title: "[Improvement][Module Name] Improvement title"
-labels: improvement
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -2,7 +2,6 @@
 name: Question
 about: Have a question wanted to be help
 title: "[Question] Question title"
-labels: question
 assignees: ''
 
 ---


### PR DESCRIPTION
The issue label should be handed over to people who are familiar with the project to mark. Currently, the label is automatically marked, and the application effect is not ideal.

A good application of the issue tag can help us save a lot of energy, so I recommend removing the automatic tag.