### PR TITLE
[Fix-4641][Alert] Sending the email to the following server failed :null:null

### DIFF
--- a/dolphinscheduler-alert-plugin/dolphinscheduler-alert-email/src/main/java/org/apache/dolphinscheduler/plugin/alert/email/MailParamsConstants.java
+++ b/dolphinscheduler-alert-plugin/dolphinscheduler-alert-email/src/main/java/org/apache/dolphinscheduler/plugin/alert/email/MailParamsConstants.java
@@ -33,33 +33,33 @@ public class MailParamsConstants {
     public static final String NAME_PLUGIN_DEFAULT_EMAIL_RECEIVERCCS = "receiverCcs";
 
     public static final String MAIL_PROTOCOL = "transport.protocol";
-    public static final String NAME_MAIL_PROTOCOL = "protocol";
+    public static final String NAME_MAIL_PROTOCOL = "mail.protocol";
 
-    public static final String MAIL_SMTP_HOST = "smtp.host";
+    public static final String MAIL_SMTP_HOST = "mail.smtp.host";
     public static final String NAME_MAIL_SMTP_HOST = "serverHost";
 
-    public static final String MAIL_SMTP_PORT = "smtp.port";
+    public static final String MAIL_SMTP_PORT = "mail.smtp.port";
     public static final String NAME_MAIL_SMTP_PORT = "serverPort";
 
-    public static final String MAIL_SENDER = "sender";
+    public static final String MAIL_SENDER = "mail.sender";
     public static final String NAME_MAIL_SENDER = "sender";
 
-    public static final String MAIL_SMTP_AUTH = "smtp.auth";
+    public static final String MAIL_SMTP_AUTH = "mail.smtp.auth";
     public static final String NAME_MAIL_SMTP_AUTH = "enableSmtpAuth";
 
-    public static final String MAIL_USER = "user";
+    public static final String MAIL_USER = "mail.user";
     public static final String NAME_MAIL_USER = "user";
 
-    public static final String MAIL_PASSWD = "passwd";
+    public static final String MAIL_PASSWD = "mail.passwd";
     public static final String NAME_MAIL_PASSWD = "passwd";
 
-    public static final String MAIL_SMTP_STARTTLS_ENABLE = "smtp.starttls.enable";
+    public static final String MAIL_SMTP_STARTTLS_ENABLE = "mail.smtp.starttls.enable";
     public static final String NAME_MAIL_SMTP_STARTTLS_ENABLE = "starttlsEnable";
 
-    public static final String MAIL_SMTP_SSL_ENABLE = "smtp.ssl.enable";
+    public static final String MAIL_SMTP_SSL_ENABLE = "mail.smtp.ssl.enable";
     public static final String NAME_MAIL_SMTP_SSL_ENABLE = "sslEnable";
 
-    public static final String MAIL_SMTP_SSL_TRUST = "smtp.ssl.trust";
+    public static final String MAIL_SMTP_SSL_TRUST = "mail.smtp.ssl.trust";
     public static final String NAME_MAIL_SMTP_SSL_TRUST = "smtpSslTrust";
 
 }

--- a/dolphinscheduler-alert-plugin/dolphinscheduler-alert-email/src/test/java/org/apache/dolphinscheduler/plugin/alert/email/MailUtilsTest.java
+++ b/dolphinscheduler-alert-plugin/dolphinscheduler-alert-email/src/test/java/org/apache/dolphinscheduler/plugin/alert/email/MailUtilsTest.java
@@ -53,6 +53,7 @@ public class MailUtilsTest {
         emailConfig.put(MailParamsConstants.NAME_MAIL_SENDER, "xxx1.xxx.com");
         emailConfig.put(MailParamsConstants.NAME_MAIL_USER, "xxx2.xxx.com");
         emailConfig.put(MailParamsConstants.NAME_MAIL_PASSWD, "111111");
+        emailConfig.put(MailParamsConstants.NAME_MAIL_SMTP_AUTH, "true");
         emailConfig.put(MailParamsConstants.NAME_MAIL_SMTP_STARTTLS_ENABLE, "true");
         emailConfig.put(MailParamsConstants.NAME_MAIL_SMTP_SSL_ENABLE, "false");
         emailConfig.put(MailParamsConstants.NAME_MAIL_SMTP_SSL_TRUST, "false");


### PR DESCRIPTION
## What is the purpose of the pull request
this PR closes #4641 
fix Alert-server email alert error, the message is 'Sending the email to the following server failed :null:null'


## Verify this pull request
This change added tests and can be verified as follows:
  - *Manually verified the change by testing locally.*

![image](https://user-images.githubusercontent.com/37063904/106416291-06f74700-648c-11eb-9461-31ab01d6f1c5.png)

