### PR TITLE
[Bug-#4640][UI] Fixed a 404 error when the project name contains "http"

### DIFF
--- a/dolphinscheduler-ui/src/js/module/io/index.js
+++ b/dolphinscheduler-ui/src/js/module/io/index.js
@@ -22,7 +22,7 @@ const apiPrefix = '/dolphinscheduler'
 const reSlashPrefix = /^\/+/
 
 const resolveURL = (url) => {
-  if (url.indexOf('http') !== -1) {
+  if (url.indexOf('http') === 0) {
     return url
   }
   if (url.charAt(0) !== '/') {


### PR DESCRIPTION
Create a new project the name contain "http"，If you enter the project process list, an Error 404 will be reported，and the interface of the new process will also report an Error 404, and the URL path of the front-end splicing is not correct


this closes #4640 
## Brief change log
before change
```
const resolveURL = (url) => {
  if (url.indexOf('http')  !== -1) {
    return url
  }
  if (url.charAt(0) !== '/') {
    return `${apiPrefix}/${url.replace(reSlashPrefix, '')}`
  }

  return url
}
```

after change
```
const resolveURL = (url) => {
  if (url.indexOf('http')  === 0) {
    return url
  }
  if (url.charAt(0) !== '/') {
    return `${apiPrefix}/${url.replace(reSlashPrefix, '')}`
  }

  return url
}
```


## Verify this pull request

*(Please pick either of the following options)*

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added dolphinscheduler-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.*
