### PR TITLE
[1.3.5-prepare][Fix][Flink] Fix flink -yn option missing after upgrading

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/FlinkArgsUtils.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/FlinkArgsUtils.java
@@ -64,9 +64,9 @@ public class FlinkArgsUtils {
                 args.add(ArgsUtils.escape(appName));
             }
 
-            // judge flink version,from flink1.10,the parameter -yn removed
+            // judge flink version, the parameter -yn has removed from flink 1.10
             String flinkVersion = param.getFlinkVersion();
-            if (FLINK_VERSION_BEFORE_1_10.equals(flinkVersion)) {
+            if (flinkVersion == null || FLINK_VERSION_BEFORE_1_10.equals(flinkVersion)) {
                 int taskManager = param.getTaskManager();
                 if (taskManager != 0) {                        //-yn
                     args.add(Constants.FLINK_TASK_MANAGE);


### PR DESCRIPTION
Fix flink `-yn` option missing after upgrading