### PR TITLE
[Fix][UDF] Fix udf jar path not exist when fs.defaultFS starts with file:///

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/UDFUtils.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/UDFUtils.java
@@ -73,13 +73,11 @@ public class UDFUtils {
         String resourceFullName;
         Set<Map.Entry<UdfFunc,String>> entries = udfFuncTenantCodeMap.entrySet();
         for (Map.Entry<UdfFunc,String> entry:entries){
+            String prefixPath = defaultFS.startsWith("file://") ? "file://" : defaultFS;
             String uploadPath = HadoopUtils.getHdfsUdfDir(entry.getValue());
-            if (!uploadPath.startsWith("hdfs:")) {
-                uploadPath = defaultFS + uploadPath;
-            }
             resourceFullName = entry.getKey().getResourceName();
             resourceFullName = resourceFullName.startsWith("/") ? resourceFullName : String.format("/%s",resourceFullName);
-            sqls.add(String.format("add jar %s%s", uploadPath, resourceFullName));
+            sqls.add(String.format("add jar %s%s%s", prefixPath, uploadPath, resourceFullName));
         }
 
     }


### PR DESCRIPTION
## *Tips*
- *Thanks very much for contributing to Apache DolphinScheduler.*
- *Please review https://dolphinscheduler.apache.org/en-us/community/index.html before opening a pull request.*

## What is the purpose of the pull request

*Fix udf jar path not exist when fs.defaultFS starts with file:///*
This closes #4691

## Brief change log

*(for example:)*
  - *Modify dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/utils/UDFUtils.java*

## Verify this pull request

*(Please pick either of the following options)*

This change added tests and can be verified as follows:

  - *Manually verified the change by testing locally.*
